### PR TITLE
Feat/publish public

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@digicat/components": "^1.0.0",
+    "@digicat/components": "^0.0.4",
     "@storybook/addon-essentials": "^6.1.10",
     "@storybook/react": "^6.1.10",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@digicat/components": "^0.0.3",
+    "@digicat/components": "^1.0.0",
     "@storybook/addon-essentials": "^6.1.10",
     "@storybook/react": "^6.1.10",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,6 +5,9 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "src/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "prop-types": "^15.7.2",
     "styled-components": "^5.0.1"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicat/components",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React components for Digital Catapult projects.",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicat/components",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "React components for Digital Catapult projects.",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicat/components",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "description": "React components for Digital Catapult projects.",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,14 +1054,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@digicat/components@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@digicat/components/-/components-0.0.3.tgz#16e109cfbf613dc14d8d099ac5c5ed1c35eae5fe"
-  integrity sha512-zwdPVgoQPgeVSXCBAEs/sNdMlvkiLJDN5Bb4czJvCttTAQG97Vjv5KttgPsYU+d72FGkfLhaMb/OBEmI9sYEhA==
-  dependencies:
-    prop-types "^15.7.2"
-    styled-components "^5.0.1"
-
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,6 +1054,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@digicat/components@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@digicat/components/-/components-0.0.3.tgz#16e109cfbf613dc14d8d099ac5c5ed1c35eae5fe"
+  integrity sha512-zwdPVgoQPgeVSXCBAEs/sNdMlvkiLJDN5Bb4czJvCttTAQG97Vjv5KttgPsYU+d72FGkfLhaMb/OBEmI9sYEhA==
+  dependencies:
+    prop-types "^15.7.2"
+    styled-components "^5.0.1"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"


### PR DESCRIPTION
This is changing the npm package visibility of the library
With this change, when we run `lerna publish` the version will be published on the public scoped package.