### PR TITLE
Fixes missing types for Card and Input

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -1,9 +1,25 @@
 declare module '@digicat/components' {
 
   interface ButtonProps {
-   outlined?: boolean
-   text?: boolean
+    variant: 'contained' | 'outlined' | 'text'
+  }
+
+  interface InputProps {
+    label: string
+    id: string
+    error?: string
+    type?: string
+    monetary?: bool
+  }
+  
+  interface CardProps {
+    title: string
+    name: string
+    date: Date
+    description: string
   }
 
   export const Button: (props: ButtonProps) => <JSXElement>
+  export const Input: (props: InputProps) => <JSXElement>
+  export const Card: (props: CardProps) => <JSXElement>
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicat/components",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "React components for Digital Catapult projects.",
   "license": "Apache-2.0",
   "modules": "lib/index.js",

--- a/packages/components/src/Button/Button.js
+++ b/packages/components/src/Button/Button.js
@@ -7,33 +7,39 @@ import colors from '../colors'
 const { white, black, grey } = colors
 
 const StyledButton = styled.button`
-  border: ${({ outlined }) => (outlined ? `1px solid ${black}` : 'none')};
-  background-color: ${({ outlined, text, disabled }) =>
-    (disabled && grey) || (outlined && white) || (text && white) || black};
-  color: ${({ outlined, text }) => (outlined || text ? black : white)};
+  border: ${({ variant }) =>
+    variant === 'outlined' ? `1px solid ${black}` : 'none'};
+  background-color: ${({ variant, disabled }) =>
+    (disabled && grey) ||
+    (variant === 'outlined' && white) ||
+    (variant === 'text' && white) ||
+    black};
+  color: ${({ variant }) =>
+    variant === 'outlined' || variant === 'text' ? black : white};
   text-transform: uppercase;
   font-weight: 600;
-  min-width: ${({ text }) => (text ? '10px' : '160px')};
+  min-width: ${({ variant }) => (variant === 'text' ? '10px' : '160px')};
   height: 45px;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 `
 
-const Button = ({ children, outlined, text, ...rest }) => (
-  <StyledButton outlined={outlined} text={text} {...rest}>
+const Button = ({ children, variant, ...rest }) => (
+  <StyledButton variant={variant} {...rest}>
     {children}
   </StyledButton>
 )
 
 Button.defaultProps = {
   children: 'button',
-  outlined: false,
-  text: false
+  variant: 'contained'
 }
 
 Button.propTypes = {
-  children: PropTypes.string,
-  outlined: PropTypes.bool,
-  text: PropTypes.bool
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
+  variant: PropTypes.oneOf(['contained', 'outlined', 'text'])
 }
 
 export default Button

--- a/packages/components/src/Button/Button.spec.js
+++ b/packages/components/src/Button/Button.spec.js
@@ -9,4 +9,18 @@ describe('Button', () => {
     const tree = renderer.create(<Button>Test</Button>).toJSON()
     expect(tree).toMatchSnapshot()
   })
+  test('outlined', () => {
+    const tree = renderer
+      .create(<Button variant="outlined">Test</Button>)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+  test('text', () => {
+    const tree = renderer.create(<Button variant="text">Test</Button>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+  test('disabled', () => {
+    const tree = renderer.create(<Button disabled>Test</Button>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/packages/components/src/Button/__snapshots__/Button.spec.js.snap
+++ b/packages/components/src/Button/__snapshots__/Button.spec.js.snap
@@ -18,3 +18,61 @@ exports[`Button default 1`] = `
   Test
 </button>
 `;
+
+exports[`Button disabled 1`] = `
+.c0 {
+  border: none;
+  background-color: #D1D1D1;
+  color: #FFFFFF;
+  text-transform: uppercase;
+  font-weight: 600;
+  min-width: 160px;
+  height: 45px;
+  cursor: default;
+}
+
+<button
+  className="c0"
+  disabled={true}
+>
+  Test
+</button>
+`;
+
+exports[`Button outlined 1`] = `
+.c0 {
+  border: 1px solid #000000;
+  background-color: #FFFFFF;
+  color: #000000;
+  text-transform: uppercase;
+  font-weight: 600;
+  min-width: 160px;
+  height: 45px;
+  cursor: pointer;
+}
+
+<button
+  className="c0"
+>
+  Test
+</button>
+`;
+
+exports[`Button text 1`] = `
+.c0 {
+  border: none;
+  background-color: #FFFFFF;
+  color: #000000;
+  text-transform: uppercase;
+  font-weight: 600;
+  min-width: 10px;
+  height: 45px;
+  cursor: pointer;
+}
+
+<button
+  className="c0"
+>
+  Test
+</button>
+`;

--- a/packages/components/src/Card/Card.js
+++ b/packages/components/src/Card/Card.js
@@ -62,7 +62,7 @@ const Card = ({ title, name, date, description, ...rest }) => {
 Card.propTypes = {
   title: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  date: PropTypes.instanceOf(Date),
+  date: PropTypes.instanceOf(Date).isRequired,
   description: PropTypes.string.isRequired
 }
 

--- a/storybook/stories/Button.stories.js
+++ b/storybook/stories/Button.stories.js
@@ -10,13 +10,8 @@ export default {
       description:
         'Style object will be passed as inline style as default behaviour of react elements. You can also use styled-components instead of this property which will also overwrite the default styles.'
     },
-    outlined: {
-      name: 'outlined',
-      description: 'has borders only'
-    },
-    text: {
-      name: 'text',
-      description: 'has no background and no borders'
+    variant: {
+      name: 'variant'
     }
   }
 }
@@ -27,10 +22,10 @@ export const Primary = Template.bind({})
 Primary.args = {}
 
 export const Outlined = Template.bind({})
-Outlined.args = { outlined: true }
+Outlined.args = { variant: 'outlined' }
 
 export const Text = Template.bind({})
-Text.args = { text: true }
+Text.args = { variant: 'text' }
 
 export const Disabled = Template.bind({})
 Disabled.args = { disabled: true }


### PR DESCRIPTION
---
name: Fix missing types
about: Adds missing types for Card and Input components
---

<!--

Have you read ui-component-library's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/ui-component-library/.github/blob/master/CODE_OF_CONDUCT.md

---
Also, note that the Digital Catapult team has finite resources so it's unlikely that we'll work on feature requests. If we're interested in a particular feature, however, we'll follow up and ask you to submit an RFC to talk about it in more detail.

-->

## Summary
This is fixing a bug that was created by the previous merge which was missing types of Card and Input components. 
This PR is also changing the variant addition to the Button which is also necessary as the boolean types are more confusing.
<!-- One paragraph explanation of the feature. -->

## Motivation

Fixing a bug

<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
