### PR TITLE
Map point filtering

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,5 +1,5 @@
 {
-  ignores: [
+  "ignores": [
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
     "@storybook/addon-actions",
@@ -8,6 +8,7 @@
     "@storybook/manager-webpack5",
     "@storybook/source-loader",
     "@types/*",
-    "jest-environment-jsdom"
+    "jest-environment-jsdom",
+    "geojson"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@storybook/manager-webpack5": "^6.5.14",
         "@storybook/react": "^6.5.14",
         "@storybook/source-loader": "^6.5.14",
+        "@types/geojson": "^7946.0.10",
         "@types/jest": "^29.2.4",
         "@types/mapbox-gl": "^2.7.10",
         "@types/node": "^18.11.15",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@storybook/manager-webpack5": "^6.5.14",
     "@storybook/react": "^6.5.14",
     "@storybook/source-loader": "^6.5.14",
+    "@types/geojson": "^7946.0.10",
     "@types/jest": "^29.2.4",
     "@types/mapbox-gl": "^2.7.10",
     "@types/node": "^18.11.15",

--- a/src/Map/Map.stories.tsx
+++ b/src/Map/Map.stories.tsx
@@ -10,33 +10,42 @@ export default {
   component: Map,
   argTypes: {
     sourceJson: {
-      control: 'text',
+      control: 'object',
     },
     style: {
       control: 'text',
+      table: {
+        category: 'Initial state',
+      },
     },
     height: {
       control: 'text',
+      table: {
+        category: 'Initial state',
+      },
     },
     width: {
       control: 'text',
+      table: {
+        category: 'Initial state',
+      },
     },
     startPositionLong: {
       control: 'number',
       table: {
-        category: 'Start Position',
+        category: 'Initial state',
       },
     },
     startPositionLat: {
       control: 'number',
       table: {
-        category: 'Start Position',
+        category: 'Initial state',
       },
     },
     startPositionZoom: {
       control: 'number',
       table: {
-        category: 'Start Position',
+        category: 'Initial state',
       },
     },
     cluster: {
@@ -111,17 +120,15 @@ export default {
 const Template = (args) => {
   const props = {
     token: process.env.STORYBOOK_MAPBOX_TOKEN,
-    size: {
-      height: args.height,
-      width: args.width,
-    },
-    startPosition: {
+    sourceJson: args.sourceJson,
+    initialState: {
       long: args.startPositionLong,
       lat: args.startPositionLat,
       zoom: args.startPositionZoom,
+      height: args.height,
+      width: args.width,
+      style: args.style,
     },
-    style: args.style,
-    sourceJson: args.sourceJson,
     cluster: args.cluster,
     clusterOptions: {
       clusterMaxZoom: args.clusterMaxZoom,

--- a/src/Map/Map.tsx
+++ b/src/Map/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react'
+import React, { useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import mapboxgl, {
   LngLatLike,


### PR DESCRIPTION
- Points on map can be filtered by setting a new GeoJSON in `props.sourceJson`. Filters without map reload.
- Auto reload map when certain props change: 
![image](https://user-images.githubusercontent.com/40722025/207911306-0e7728bc-b99f-4282-b580-4cd5828d3640.png)
- Other props don't cause an auto reload (but they could if we wanted)


