### PR TITLE
Fix module type commonjs

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,17 @@
+{
+  "sourceType": "unambiguous",
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": "commonjs",
+        "targets": {
+          "chrome": 100
+        }
+      }
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ],
+  "plugins": []
+}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   stories: [
     '../src/**/*.stories.mdx',
     '../src/**/*.stories.@(js|jsx|ts|tsx)'
@@ -8,6 +8,9 @@ module.exports = {
     builder: 'webpack5'
   },
   framework: '@storybook/react',
+  features: {
+    babelModeV7: true,
+  },
   typescript: {
     check: true,
     reactDocgen: 'react-docgen-typescript',
@@ -15,7 +18,6 @@ module.exports = {
       compilerOptions: {
         allowSyntheticDefaultImports: false,
         esModuleInterop: false,
-        
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",
@@ -15,6 +15,9 @@
         "styled-components": "^5.3.6"
       },
       "devDependencies": {
+        "@babel/preset-env": "^7.20.2",
+        "@babel/preset-react": "^7.18.6",
+        "@babel/preset-typescript": "^7.18.6",
         "@storybook/addon-actions": "^6.5.14",
         "@storybook/addon-essentials": "^6.5.14",
         "@storybook/addon-links": "^6.5.14",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",
-  "type": "module",
+  "type": "commonjs",
   "main": "lib/index.js",
   "files": [
     "/lib"
@@ -36,6 +36,9 @@
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.18.6",
     "@storybook/addon-actions": "^6.5.14",
     "@storybook/addon-essentials": "^6.5.14",
     "@storybook/addon-links": "^6.5.14",


### PR DESCRIPTION
Now our build exports a commonjs module we need to tell the package.json this is the case. This fixes that. Unfortunately that change breaks storybook. I've then switched storybook to use their new bable configuration mechanism https://storybook.js.org/docs/react/configure/babel and configured the modules toalways be commonjs. This feels like a bit of a hack but I think it works.
