### PR TITLE
Fix search icon when box-sizing is border-box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Search/__snapshots__/Search.spec.js.snap
+++ b/src/Search/__snapshots__/Search.spec.js.snap
@@ -57,39 +57,42 @@ exports[`Test default 1`] = `
   flex-shrink: 0;
   width: 2em;
   height: 2em;
-  box-sizing: border-box;
   background: transparent;
   border: 0;
+}
+
+.c2,
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c2:focus {
   outline: 0;
 }
 
-.c2:focus::before {
-  box-shadow: 0 0 5px 1px black;
-}
-
+.c2:focus::before,
 .c2:focus::after {
   box-shadow: 0 0 5px 1px black;
 }
 
-.c2::before {
+.c2::before,
+.c2::after {
   content: '';
   display: block;
   position: absolute;
+}
+
+.c2::before {
   left: 0;
   top: 0;
-  width: calc(80% - 2 * 4em / 16);
-  height: calc(80% - 2 * 4em / 16);
+  width: 80%;
+  height: 80%;
   border: calc(4em / 16) solid black;
   border-radius: 50%;
 }
 
 .c2::after {
-  content: '';
-  display: block;
-  position: absolute;
   right: 0;
   bottom: 0;
   height: calc(4em / 16);
@@ -183,39 +186,42 @@ exports[`Test with props 1`] = `
   flex-shrink: 0;
   width: 2em;
   height: 2em;
-  box-sizing: border-box;
   background: transparent;
   border: 0;
+}
+
+.c2,
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c2:focus {
   outline: 0;
 }
 
-.c2:focus::before {
-  box-shadow: 0 0 5px 1px green;
-}
-
+.c2:focus::before,
 .c2:focus::after {
   box-shadow: 0 0 5px 1px green;
 }
 
-.c2::before {
+.c2::before,
+.c2::after {
   content: '';
   display: block;
   position: absolute;
+}
+
+.c2::before {
   left: 0;
   top: 0;
-  width: calc(80% - 2 * 4em / 16);
-  height: calc(80% - 2 * 4em / 16);
+  width: 80%;
+  height: 80%;
   border: calc(4em / 16) solid green;
   border-radius: 50%;
 }
 
 .c2::after {
-  content: '';
-  display: block;
-  position: absolute;
   right: 0;
   bottom: 0;
   height: calc(4em / 16);

--- a/src/Search/index.tsx
+++ b/src/Search/index.tsx
@@ -114,36 +114,36 @@ const SearchIcon = styled.button<SearchIconProps>`
   flex-shrink: 0;
   width: 2em;
   height: 2em;
-  box-sizing: border-box;
   background: transparent;
   border: 0;
 
+  &, ::before, ::after {
+    box-sizing: border-box;
+  }
+
   :focus {
-    ::before {
-      box-shadow: 0 0 5px 1px ${({ color }) => color};
-    }
-    ::after {
+    ::before, ::after {
       box-shadow: 0 0 5px 1px ${({ color }) => color};
     }
     outline: 0;
   }
 
-  ::before {
+  ::before, ::after {
     content: '';
     display: block;
     position: absolute;
+  }
+
+  ::before {
     left: 0;
     top: 0;
-    width: calc(80% - 2 * 4em / 16);
-    height: calc(80% - 2 * 4em / 16);
+    width: 80%;
+    height: 80%;
     border: calc(4em / 16) solid ${({ color }) => color};
     border-radius: 50%;
   }
 
   ::after {
-    content: '';
-    display: block;
-    position: absolute;
     right: 0;
     bottom: 0;
     height: calc(4em / 16);


### PR DESCRIPTION
Bug if a css reset on box-sizing is used for example:

```css
*, *::before, *::after {
  box-sizing: border-box
}
```

Original:
![Screenshot 2023-01-03 at 13 59 06](https://user-images.githubusercontent.com/29942957/210374183-f6f35ed9-534b-4483-94b6-25b07a644653.png)
Fixed:
![Screenshot 2023-01-03 at 14 00 10](https://user-images.githubusercontent.com/29942957/210374203-c6872f29-1d32-4878-bb9b-40be4bd30d63.png)
