### PR TITLE
Improve `npm link` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This will open the browser and will run storybook at [localhost:9000](http://loc
 
 ## Local linking for development
 
-If you want to link @digicatapult/ui-component-library to your project while developing
+If you want to link `@digicatapult/ui-component-library` to your project while developing
 
 run
 
@@ -80,11 +80,14 @@ run
 npm run build:watch
 ```
 
+In another terminal, `npm link` to your project's `react`. This prevents issues arising from two Reacts — one in the project folder and the one in `ui-component-library`. Next create a global symlink for `ui-component-library` e.g.
+
 ```bash
-npm run link
+npm link ../hii-client/node_modules/react
+npm link
 ```
 
-In your project run the following command
+Finally, in your project run the following command
 
 ```bash
 npm link "@digicatapult/ui-component-library"


### PR DESCRIPTION
Using `npm link` with this library and `hii-client` was erroring `You might have more than one copy of React in the same app` when starting `hii-client`

Add clarification in README on how to avoid a React conflict when linking. Solution from https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react