### PR TITLE
Enforce js extension on imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,13 +31,27 @@
     "react/no-array-index-key": 0,
     "import/no-extraneous-dependencies": [
       "error",
-      { "devDependencies": ["**/*.spec.tsx", "**/*.stories.*", "src/utils/story-helpers.tsx"], "peerDependencies": true }
-    ]
+      {
+        "devDependencies": [
+          "**/*.spec.tsx",
+          "**/*.stories.*",
+          "src/utils/story-helpers.tsx"
+        ],
+        "peerDependencies": true
+      }
+    ],
+    "import/extensions": ["error", "ignorePackages", { "js": "always" }]
   },
   "env": { "es6": true, "jest/globals": true },
   "overrides": [
     {
       "files": ["src/**/*.{js,jsx,ts,tsx}"]
+    },
+    {
+      "files": ["src/**/*.stories.{ts|tsx}"],
+      "rules": {
+        "import/extensions": ["error", "ignorePackages"]
+      }
     }
   ]
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,7 +11,7 @@ export default {
   webpackFinal(config) {
     delete config.resolve.extensions
     config.resolve.extensionAlias = {
-      '.js': ['.ts', '.js', '.tsx'],
+      '.js': ['.ts', '.js', '.tsx']
     }
     return config
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Ensure imports actually are js and therefore the package is likely to be valid. Done through linting as that was easiest. ~Also add some padding to a component as requested by @n3op2 in #46~ (removed in favour of #49)

Note failure on https://github.com/digicatapult/ui-component-library/actions/runs/3848513863/jobs/6556395360