### PR TITLE
Increase point on zoom & border

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Map/Map.stories.tsx
+++ b/src/Map/Map.stories.tsx
@@ -165,6 +165,9 @@ const Template: Story = (args) => {
       pointExpression: args.pointExpression,
       pointColor: args.pointColor,
       pointRadius: args.pointRadius,
+      pointRadiusExpression: args.pointRadiusExpression,
+      pointStrokeWidth: args.pointStrokeWidth,
+      pointStrokeColor: args.pointStrokeColor,
       onPointClick: action('click'),
       onClickZoomIn: args.onClickZoomIn,
     },
@@ -192,5 +195,7 @@ export const HIIPointColour = Template.bind({})
 HIIPointColour.args = {
   sourceJson: hiiJson,
   pointExpression: pointColourExpression,
-  pointRadius: 4,
+  pointRadiusExpression: ['interpolate', ['linear'], ['zoom'], 1, 5, 10, 10],
+  pointStrokeColor: '#8a8988',
+  pointStrokeWidth: 1,
 }

--- a/src/Map/index.tsx
+++ b/src/Map/index.tsx
@@ -33,6 +33,9 @@ export interface PointOptions {
   pointExpression?: Expression
   pointColor?: string
   pointRadius?: number
+  pointRadiusExpression?: Expression
+  pointStrokeWidth?: number
+  pointStrokeColor?: string
   onPointClick?: (feature: MapboxGeoJSONFeature) => void
   onClickZoomIn?: number
 }
@@ -66,7 +69,10 @@ const applyLayerDefaults = (props: Props) => {
     pointOptions: {
       pointExpression: props.pointOptions?.pointExpression || null,
       pointColor: props.pointOptions?.pointColor || colors.black,
-      pointRadius: props.pointOptions?.pointRadius || 6,
+      pointRadius: props.pointOptions?.pointRadius || 5,
+      pointRadiusExpression: props.pointOptions?.pointRadiusExpression || null,
+      pointStrokeWidth: props.pointOptions?.pointStrokeWidth || 0,
+      pointStrokeColor: props.pointOptions?.pointStrokeColor || colors.white,
       onPointClick: props.pointOptions?.onPointClick || Function(),
       onClickZoomIn: props.pointOptions?.onClickZoomIn || 12,
     },
@@ -92,6 +98,9 @@ const Map: React.FC<Props> = (props) => {
       pointExpression,
       pointColor,
       pointRadius,
+      pointRadiusExpression,
+      pointStrokeWidth,
+      pointStrokeColor,
       onPointClick,
       onClickZoomIn,
     },
@@ -195,7 +204,10 @@ const Map: React.FC<Props> = (props) => {
         paint: {
           'circle-color':
             pointExpression != null ? pointExpression : pointColor,
-          'circle-radius': pointRadius,
+          'circle-radius':
+            pointRadiusExpression != null ? pointRadiusExpression : pointRadius,
+          'circle-stroke-color': pointStrokeColor,
+          'circle-stroke-width': pointStrokeWidth,
         },
       })
 


### PR DESCRIPTION
This adds several attributes which allows the radius to be fixed or use an expression to linearly interpolate between zoom levels. Also adds border attributes to change the colour and width.

`pointRadiusExpression,
  pointStrokeWidth,
  pointStrokeColor,`

Before:

<img width="797" alt="Screenshot 2023-01-05 at 16 30 43" src="https://user-images.githubusercontent.com/35331926/210832223-18502577-c4ba-45b6-844a-0f7a146cd89b.png">

After:

<img width="797" alt="Screenshot 2023-01-05 at 16 31 34" src="https://user-images.githubusercontent.com/35331926/210832260-0eea773a-c6a9-4f2d-8e19-f7ff10d59b11.png">

<img width="797" alt="Screenshot 2023-01-05 at 16 31 47" src="https://user-images.githubusercontent.com/35331926/210832299-acba99bf-ba0c-40fd-ab2b-50fb1f41614f.png">

