### PR TITLE
Implement search lexer for breaking up search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.5.8",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",
+        "moo": "^0.5.2",
         "react-id-generator": "^3.0.2",
         "react-select": "^5.7.0",
         "styled-components": "^5.3.6"
@@ -28,6 +29,7 @@
         "@types/geojson": "^7946.0.10",
         "@types/jest": "^29.2.4",
         "@types/mapbox-gl": "^2.7.10",
+        "@types/moo": "^0.5.5",
         "@types/node": "^18.11.15",
         "@types/prop-types": "^15.7.5",
         "@types/react": "^18.0.26",
@@ -10026,6 +10028,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
+    "node_modules/@types/moo": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/moo/-/moo-0.5.5.tgz",
+      "integrity": "sha512-eXQpwnkI4Ntw5uJg6i2PINdRFWLr55dqjuYQaLHNjvqTzF14QdNWbCbml9sza0byyXNA0hZlHtcdN+VNDcgVHA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -21473,9 +21481,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -22487,6 +22495,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -27322,9 +27335,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -36547,6 +36560,12 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
+    "@types/moo": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/moo/-/moo-0.5.5.tgz",
+      "integrity": "sha512-eXQpwnkI4Ntw5uJg6i2PINdRFWLr55dqjuYQaLHNjvqTzF14QdNWbCbml9sza0byyXNA0hZlHtcdN+VNDcgVHA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
@@ -45388,9 +45407,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -46201,6 +46220,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -50022,9 +50046,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "mapbox-gl": "^2.11.1",
+    "moo": "^0.5.2",
     "react-id-generator": "^3.0.2",
     "react-select": "^5.7.0",
     "styled-components": "^5.3.6"
@@ -51,6 +52,7 @@
     "@types/geojson": "^7946.0.10",
     "@types/jest": "^29.2.4",
     "@types/mapbox-gl": "^2.7.10",
+    "@types/moo": "^0.5.5",
     "@types/node": "^18.11.15",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^18.0.26",

--- a/src/Search/Search.spec.tsx
+++ b/src/Search/Search.spec.tsx
@@ -74,7 +74,16 @@ describe('Test', () => {
     })
 
     const tree = instance.toJSON()
-    expect(submitEvents).toEqual(['test'])
+    expect(submitEvents).toEqual([
+      [
+        {
+          isQuoted: false,
+          modifier: null,
+          type: 'term',
+          value: 'test',
+        },
+      ],
+    ])
   })
 
   test('manual-submit (immediate)', async () => {
@@ -101,7 +110,16 @@ describe('Test', () => {
     })
 
     const tree = instance.toJSON()
-    expect(submitEvents).toEqual(['test'])
+    expect(submitEvents).toEqual([
+      [
+        {
+          isQuoted: false,
+          modifier: null,
+          type: 'term',
+          value: 'test',
+        },
+      ],
+    ])
     expect(eventMock.preventDefault.mock.calls).toHaveLength(1)
   })
 
@@ -129,7 +147,16 @@ describe('Test', () => {
     })
 
     const tree = instance.toJSON()
-    expect(submitEvents).toEqual(['test'])
+    expect(submitEvents).toEqual([
+      [
+        {
+          isQuoted: false,
+          modifier: null,
+          type: 'term',
+          value: 'test',
+        },
+      ],
+    ])
   })
 
   test('reset to null', async () => {
@@ -161,6 +188,16 @@ describe('Test', () => {
     })
 
     const tree = instance.toJSON()
-    expect(submitEvents).toEqual(['test', null])
+    expect(submitEvents).toEqual([
+      [
+        {
+          isQuoted: false,
+          modifier: null,
+          type: 'term',
+          value: 'test',
+        },
+      ],
+      [],
+    ])
   })
 })

--- a/src/Search/Search.stories.tsx
+++ b/src/Search/Search.stories.tsx
@@ -18,6 +18,13 @@ const DefaultStoryTemplate: Story = (args) => {
       fontSize={args.fontSize}
     >
       <Search
+        fields={{
+          project: { fieldType: 'text' },
+          startDate: { fieldType: 'date' },
+          endDate: { fieldType: 'date' },
+          funding: { fieldType: 'currency' },
+          publicationCount: { fieldType: 'number' },
+        }}
         placeholder={args.placeholder}
         color={args.color}
         background={args.background}

--- a/src/Search/lexer.spec.ts
+++ b/src/Search/lexer.spec.ts
@@ -1,0 +1,94 @@
+import { buildLexer, parseSearch } from './lexer.js'
+import { SearchFields } from './index.js'
+
+const defaultFields: SearchFields = {
+  test: {
+    fieldType: 'text'
+  }
+}
+const defaultLexer = buildLexer(defaultFields)
+
+describe('lexer', () => {
+  test('just terms', () => {
+    const result = parseSearch(defaultLexer, 'hello world')
+    expect(result).toEqual([
+      { type: 'term', value: 'hello', modifier: null, isQuoted: false },
+      { type: 'term', value: 'world', modifier: null, isQuoted: false }
+    ])
+  })
+
+  test('quoted terms', () => {
+    const result = parseSearch(defaultLexer, '"hello world"')
+    expect(result).toEqual([{ type: 'term', value: 'hello world', modifier: null, isQuoted: true }])
+  })
+
+  test('modified terms', () => {
+    const result = parseSearch(defaultLexer, 'hello +world -universe')
+    expect(result).toEqual([
+      { type: 'term', value: 'hello', modifier: null, isQuoted: false },
+      { type: 'term', value: 'world', modifier: 'positive', isQuoted: false },
+      { type: 'term', value: 'universe', modifier: 'negative', isQuoted: false }
+    ])
+  })
+
+  test('escaped quote in quoted terms', () => {
+    const result = parseSearch(defaultLexer, '"hello\\" world"')
+    expect(result).toEqual([{ type: 'term', value: 'hello" world', modifier: null, isQuoted: true }])
+  })
+
+  test('escaped quote in plain terms', () => {
+    const result = parseSearch(defaultLexer, '\\"hello\\" \\"world\\"')
+    expect(result).toEqual([
+      { type: 'term', value: '"hello"', modifier: null, isQuoted: false },
+      { type: 'term', value: '"world"', modifier: null, isQuoted: false }
+    ])
+  })
+
+  test('just field match', () => {
+    const result = parseSearch(defaultLexer, 'test:me')
+    expect(result).toEqual([{ type: 'fieldMatch', field: 'test', value: 'me', modifier: null, isQuoted: false }])
+  })
+
+  test('mixture terms and fields', () => {
+    const result = parseSearch(defaultLexer, 'hello world test:me')
+    expect(result).toEqual([
+      { type: 'term', value: 'hello', modifier: null, isQuoted: false },
+      { type: 'term', value: 'world', modifier: null, isQuoted: false },
+      { type: 'fieldMatch', field: 'test', value: 'me', modifier: null, isQuoted: false }
+    ])
+  })
+
+  test('reorder terms and fields', () => {
+    const result = parseSearch(defaultLexer, 'hello test:me world')
+    expect(result).toEqual([
+      { type: 'term', value: 'hello', modifier: null, isQuoted: false },
+      { type: 'fieldMatch', field: 'test', value: 'me', modifier: null, isQuoted: false },
+      { type: 'term', value: 'world', modifier: null, isQuoted: false }
+    ])
+  })
+
+  test('quoted match field', () => {
+    const result = parseSearch(defaultLexer, 'hello test:"me world"')
+    expect(result).toEqual([
+      { type: 'term', value: 'hello', modifier: null, isQuoted: false },
+      { type: 'fieldMatch', field: 'test', value: 'me world', modifier: null, isQuoted: true }
+    ])
+  })
+
+  test('ignores invalid fields', () => {
+    const defaultFields: SearchFields = {
+      test_: {
+        fieldType: 'text'
+      }
+    }
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const invalidLexer = buildLexer(defaultFields)
+
+    expect(warn).toHaveBeenCalledWith(
+      'Invalid field test_ passed to @digicatapult/ui-component-library Search component. Field will be excluded'
+    )
+
+    const result = parseSearch(invalidLexer, 'test_:me')
+    expect(result).toEqual([{ type: 'term', value: 'test_:me', modifier: null, isQuoted: false }])
+  })
+})

--- a/src/Search/lexer.ts
+++ b/src/Search/lexer.ts
@@ -1,0 +1,105 @@
+import moo from 'moo'
+
+import { SearchFields, SearchTerm } from './index.js'
+
+const fieldValidator = /^[a-zA-Z]+$/
+export const buildLexer = (fields: SearchFields) => {
+  const fieldsArray = Object.entries(fields)
+    .map(([fieldName, fieldValue]) => ({
+      fieldName,
+      ...fieldValue
+    }))
+    .filter(({ fieldName }) => {
+      const isValid = !!fieldName.match(fieldValidator)
+      if (!isValid) {
+        console.warn(
+          `Invalid field ${fieldName} passed to @digicatapult/ui-component-library Search component. Field will be excluded`
+        )
+      }
+      return isValid
+    })
+
+  return moo.states({
+    main: {
+      fieldMatch: {
+        match: fieldsArray.map((f) => `${f.fieldName}:`),
+        value: (s) => s.slice(0, -1)
+      },
+      escape: /\\./,
+      strstart: { match: '"', push: 'lit' },
+      plusMinus: /[+-]/,
+      char: /\S/,
+      space: { match: /\s+/, lineBreaks: true }
+    },
+    lit: {
+      escape: /\\./,
+      strend: { match: /"(?:\s|$)/, pop: 1, lineBreaks: true },
+      char: { match: /./, lineBreaks: true }
+    }
+  })
+}
+
+export const parseSearch = (lexer: moo.Lexer, search: string) => {
+  const result: SearchTerm[] = []
+  let token: moo.Token | undefined
+  let type: 'term' | 'fieldMatch' = 'term'
+  let field: string = ''
+  let value: string = ''
+  let modifier: 'positive' | 'negative' | null = null
+  let isQuoted: boolean = false
+
+  const maybeAppendToResult = () => {
+    if (value) {
+      result.push(
+        type === 'term'
+          ? {
+              type,
+              value,
+              modifier,
+              isQuoted
+            }
+          : {
+              type,
+              field,
+              value,
+              modifier,
+              isQuoted
+            }
+      )
+      type = 'term'
+      field = ''
+      value = ''
+      modifier = null
+      isQuoted = false
+    }
+  }
+
+  lexer.reset(search)
+  while ((token = lexer.next())) {
+    switch (token.type) {
+      case 'fieldMatch':
+        type = token.type
+        field = token.value
+        value = ''
+        break
+      case 'plusMinus':
+        modifier = token.value === '+' ? 'positive' : 'negative'
+        break
+      case 'char':
+        value = value + token.value
+        break
+      case 'escape':
+        value = value + token.value.slice(1)
+        break
+      case 'strend':
+      case 'space':
+        maybeAppendToResult()
+        break
+      case 'strstart':
+        isQuoted = true
+        break
+    }
+  }
+  maybeAppendToResult()
+  return result
+}


### PR DESCRIPTION
Implements a search lexer for breaking up searches into different types of field lookup.

What's implemented:
1. custom field names
2. breaking up on search into terms and field matches
3. quoting to combine words into a single term
4. modifiers such as `+` and `-` so we can implement strong match and negative match
5. validation of field names to `/^[a-zA-Z]$/` so we can later implement comparitives

What's not implemented:
1. Any sort of UI indication this exists. It is hidden magic
2. Input validation for things like numbers, currency values and dates. These will have to come with a ui update to indicate sections of a search that are invalid and why
3. A form to simplify the creation of complex queries
4. Comparative queries other than matches. For example `field_greater` or `field_less`