### PR TITLE
Improve Dialog scroll bars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Dialog/Dialog.stories.tsx
+++ b/src/Dialog/Dialog.stories.tsx
@@ -160,12 +160,11 @@ export const HII: Story = () => {
       >
         {!isOpen ? 'Open' : 'Close'}
       </button>
-      <DialogComponent ref={dialogRef} includeClose={true}>
+      <DialogComponent width="47ch" ref={dialogRef} includeClose={true}>
         <Section
           headingLevel={2}
           title="Name"
           padding="1em 1.5em"
-          width="47ch"
           headingSize="2em"
           background="white"
         >

--- a/src/Dialog/__snapshots__/Dialog.spec.tsx.snap
+++ b/src/Dialog/__snapshots__/Dialog.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`Dialog default 1`] = `
 .c1 {
   display: inline-block;
   position: relative;
-  overflow: scroll;
+  overflow: auto;
   width: 100%;
   height: 100%;
 }
@@ -112,7 +112,7 @@ exports[`Dialog no close 1`] = `
 .c1 {
   display: inline-block;
   position: relative;
-  overflow: scroll;
+  overflow: auto;
   width: 100%;
   height: 100%;
 }
@@ -160,7 +160,7 @@ exports[`Dialog style overrides 1`] = `
 .c1 {
   display: inline-block;
   position: relative;
-  overflow: scroll;
+  overflow: auto;
   width: 100%;
   height: 100%;
 }

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -74,7 +74,7 @@ const Wrapper = styled.dialog<DialogProps>`
 const DialogForm = styled.form`
   display: inline-block;
   position: relative;
-  overflow: scroll;
+  overflow: auto;
   width: 100%;
   height: 100%;
 `


### PR DESCRIPTION
Makes scroll bars show correctly, and only when needed

e.g. (I've edited `dialog` to a fixed height to make scroll bars show)
![image](https://user-images.githubusercontent.com/40722025/211332591-81d7045a-4999-4318-b05b-b8dbfa31fe44.png)