### PR TITLE
Bug - Dialog height safari + overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Dialog/Dialog.stories.tsx
+++ b/src/Dialog/Dialog.stories.tsx
@@ -160,7 +160,12 @@ export const HII: Story = () => {
       >
         {!isOpen ? 'Open' : 'Close'}
       </button>
-      <DialogComponent width="47ch" ref={dialogRef} includeClose={true}>
+      <DialogComponent
+        width="47ch"
+        maxHeight="60ch"
+        ref={dialogRef}
+        includeClose={true}
+      >
         <Section
           headingLevel={2}
           title="Name"
@@ -204,7 +209,14 @@ export const HII: Story = () => {
                 at projects at a TRL of 4 to 7, which could result in lower
                 capital or operating costs when compared to Steam Methane
                 Reformation with Carbon Capture & Storage (SMR+CCS), or improve
-                the carbon capture rates at a comparable cost.
+                the carbon capture rates at a comparable cost. Scope / goal -
+                The £33 million Low Carbon Hydrogen Supply competition aimed to
+                accelerate the development of low carbon bulk hydrogen supply
+                solutions in specific sectors. It was aimed at projects at a TRL
+                of 4 to 7, which could result in lower capital or operating
+                costs when compared to Steam Methane Reformation with Carbon
+                Capture & Storage (SMR+CCS), or improve the carbon capture rates
+                at a comparable cost.
               </Section>
             </Grid.Panel>
 

--- a/src/Dialog/__snapshots__/Dialog.spec.tsx.snap
+++ b/src/Dialog/__snapshots__/Dialog.spec.tsx.snap
@@ -12,9 +12,6 @@ exports[`Dialog default 1`] = `
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
 }
 
 .c0::backdrop {
@@ -25,8 +22,8 @@ exports[`Dialog default 1`] = `
   display: inline-block;
   position: relative;
   overflow: auto;
-  width: 100%;
-  height: 100%;
+  max-height: inherit;
+  height: inherit;
 }
 
 .c2 {
@@ -71,7 +68,6 @@ exports[`Dialog default 1`] = `
 
 <dialog
   className="c0"
-  height="fit-content"
   width="fit-content"
 >
   <form
@@ -100,9 +96,6 @@ exports[`Dialog no close 1`] = `
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
 }
 
 .c0::backdrop {
@@ -113,8 +106,8 @@ exports[`Dialog no close 1`] = `
   display: inline-block;
   position: relative;
   overflow: auto;
-  width: 100%;
-  height: 100%;
+  max-height: inherit;
+  height: inherit;
 }
 
 .c2 {
@@ -126,7 +119,6 @@ exports[`Dialog no close 1`] = `
 
 <dialog
   className="c0"
-  height="fit-content"
   width="fit-content"
 >
   <form
@@ -161,8 +153,8 @@ exports[`Dialog style overrides 1`] = `
   display: inline-block;
   position: relative;
   overflow: auto;
-  width: 100%;
-  height: 100%;
+  max-height: inherit;
+  height: inherit;
 }
 
 .c2 {

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -12,6 +12,7 @@ export interface DialogProps {
   boxShadow?: string
   width?: string
   height?: string
+  maxHeight?: string
 }
 
 const Dialog = React.forwardRef<
@@ -28,8 +29,9 @@ const Dialog = React.forwardRef<
       border = '0',
       boxShadow = '5px 5px 5px #90909090',
       width = 'fit-content',
-      height = 'fit-content',
+      height,
       modalBackdropColor = 'unset',
+      maxHeight,
     },
     dialogRef
   ) => {
@@ -44,6 +46,7 @@ const Dialog = React.forwardRef<
         boxShadow={boxShadow}
         width={width}
         height={height}
+        maxHeight={maxHeight}
       >
         <DialogForm method="dialog">
           {includeClose ? <CloseButton /> : null}
@@ -65,6 +68,7 @@ const Wrapper = styled.dialog<DialogProps>`
   box-shadow: ${({ boxShadow }) => boxShadow};
   width: ${({ width }) => width};
   height: ${({ height }) => height};
+  max-height: ${({ maxHeight }) => maxHeight};
 
   ::backdrop {
     background: ${({ modalBackdropColor }) => modalBackdropColor};
@@ -75,8 +79,8 @@ const DialogForm = styled.form`
   display: inline-block;
   position: relative;
   overflow: auto;
-  width: 100%;
-  height: 100%;
+  max-height: inherit;
+  height: inherit;
 `
 
 const CloseButton = styled.button`


### PR DESCRIPTION
Bug with Safari and `height: fit-content` + overflow scrolling

BEFORE
Safari
<img width="402" alt="image" src="https://user-images.githubusercontent.com/40722025/211544635-4fd68398-91d4-4e57-bf64-2f0e1cfbe4e3.png">

FF - no scroll on overflow because form has `height: 100%`
![image](https://user-images.githubusercontent.com/40722025/211544818-86de33df-9a46-417a-904a-093d884bf437.png)


AFTER
Safari
<img width="408" alt="image" src="https://user-images.githubusercontent.com/40722025/211544253-e8b1880a-be6d-4e67-8d3d-d821a48a8af9.png">
FF
![image](https://user-images.githubusercontent.com/40722025/211544370-048b1142-1092-49b4-9c77-4d361f1ca0aa.png)


- Use `max-height`for the whole dialog, this is then `inherit`ed in the form. Means we can set a `max-height` in the client and scroll bars will show correctly, I've set a `max-height` on `Dialog - HII` story to show scrolls bars.
- Safari still lacks rounded corners because of some overflow issue but 🤷 is fine in Chrome/FF