### PR TITLE
HII-36: remove overflow property.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Drawer/__snapshots__/Drawer.spec.tsx.snap
+++ b/src/Drawer/__snapshots__/Drawer.spec.tsx.snap
@@ -88,7 +88,6 @@ exports[`Drawer onClick 1`] = `
 }
 
 .c9 {
-  overflow-y: hidden;
   width: 100%;
   -webkit-transition: max-height 0.5s ease;
   transition: max-height 0.5s ease;
@@ -253,7 +252,6 @@ exports[`Drawer simple 1`] = `
 }
 
 .c9 {
-  overflow-y: hidden;
   width: 100%;
   -webkit-transition: max-height 0.5s ease;
   transition: max-height 0.5s ease;
@@ -418,7 +416,6 @@ exports[`Drawer with overrides 1`] = `
 }
 
 .c9 {
-  overflow-y: hidden;
   width: 100%;
   -webkit-transition: max-height 0.5s ease;
   transition: max-height 0.5s ease;

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -161,7 +161,6 @@ const DrawerHeaderWrapper = styled('button')<DrawerHeaderProps>`
 // Overflow wrapper to ensure that when we hide the content the translated element
 // doesn't overflow and instead hides the content
 const DrawerContentOverflow = styled.div<DrawerContentProps>`
-  overflow-y: hidden;
   width: 100%;
   transition: max-height 0.5s ease;
   ${({ isOpen, maxHeight }) =>


### PR DESCRIPTION
## What

It was causing hell of a trouble as I developed based on assumption that drawer WILL 100% NOT HIDE the overflow, however it was hiding it, so removing that property so drop down options can be rendered on the client


#### before
![Screenshot 2023-01-11 at 11 43 51](https://user-images.githubusercontent.com/11794402/211823090-277dac0e-2f13-4ac9-a19b-ff4372a34e65.png)


#### affter (storybook)
![Screenshot 2023-01-11 at 13 34 31](https://user-images.githubusercontent.com/11794402/211823181-b6d89716-cf1d-4eb6-9847-b9288535adbb.png)
