### PR TITLE
Zoom on markers when searching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Map/index.tsx
+++ b/src/Map/index.tsx
@@ -81,6 +81,34 @@ const applyLayerDefaults = (props: Props) => {
   }
 }
 
+const updateMap = (sourceJson: GeoJSON, map: mapboxgl.Map) => {
+  if ((sourceJson as FeatureCollection).features.length > 0) {
+    let bounds = (sourceJson as FeatureCollection).features.reduce(function (
+      bounds: any,
+      feature: any
+    ) {
+      if (!Array.isArray(feature.geometry.coordinates[0])) {
+        return bounds.extend(feature.geometry.coordinates)
+      } else {
+        return feature.geometry.coordinates.reduce(function (
+          bounds: any,
+          coord: any
+        ) {
+          return bounds.extend(coord)
+        },
+        bounds)
+      }
+    },
+    new mapboxgl.LngLatBounds())
+    map.fitBounds(bounds, {
+      linear: false,
+      maxZoom: 12,
+      speed: 0.6,
+      padding: 100,
+    })
+  }
+}
+
 const Map: React.FC<Props> = (props) => {
   const mapContainer = useRef(null)
   const mapRef = useRef<mapboxgl.Map | null>(null)
@@ -156,6 +184,9 @@ const Map: React.FC<Props> = (props) => {
 
     const geojsonSource = map.getSource('source') as GeoJSONSource
     geojsonSource?.setData(sourceJson as FeatureCollection)
+
+    // Update map on search
+    updateMap(sourceJson, map)
   }, [sourceJson])
 
   // Use to travel to location on card click

--- a/src/Map/index.tsx
+++ b/src/Map/index.tsx
@@ -49,6 +49,7 @@ export interface Props {
   pointOptions?: PointOptions
   zoomLocation?: [number, number]
   easeSpeed?: number
+  markerSearchZoom?: boolean
 }
 
 const Wrapper = styled('div')<InitialState>`
@@ -141,6 +142,7 @@ const Map: React.FC<Props> = (props) => {
   const width = props.initialState?.width || '800px'
   mapboxgl.accessToken = props.token
   const easeSpeed = props?.easeSpeed || 4000 // milliseconds
+  const markerSearchZoom = props?.markerSearchZoom || false
 
   // initialize map
   useEffect(() => {
@@ -184,10 +186,16 @@ const Map: React.FC<Props> = (props) => {
 
     const geojsonSource = map.getSource('source') as GeoJSONSource
     geojsonSource?.setData(sourceJson as FeatureCollection)
+  }, [sourceJson])
+
+  // update map fitBound area
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !sourceJson) return undefined
 
     // Update map on search
-    updateMap(sourceJson, map)
-  }, [sourceJson])
+    if (markerSearchZoom) updateMap(sourceJson, map)
+  }, [sourceJson, markerSearchZoom])
 
   // Use to travel to location on card click
   useEffect(() => {


### PR DESCRIPTION
This uses Mapbox's `fitBounds` when the user searches for a project and zooms in to accommodate all of the relevant markers. It has has a boolean, `markerSearchZoom`, that can be used in the client to turn it on or off.

https://user-images.githubusercontent.com/35331926/212701202-b6bb1a0d-9868-4298-8647-42432f640d92.mp4




