### PR TITLE
Bug - Multi dropdown select options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "Apache-2.0",
       "dependencies": {
         "mapbox-gl": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Dropdown/index.tsx
+++ b/src/Dropdown/index.tsx
@@ -133,6 +133,7 @@ const HiiMultiSelect: IDropdown = ({ onChange, value = [], ...props }) => {
           ValueContainer: HiiLabel,
         }}
         {...props}
+        value={value}
         closeMenuOnSelect={true}
         controlShouldRenderValue={true}
         onChange={onChange}


### PR DESCRIPTION
How to recreate:

Go to http://localhost:9000/?path=/story/components-dropdown--hii
Select any project type e.g.
![image](https://user-images.githubusercontent.com/40722025/212975687-b3b31174-ae82-48c6-b757-cbd625d20932.png)

Use the red X to remove that project type as a selection. Now no project types are selected.

Unexpected behaviour:
- The X to 'clear all' remains on the right hand side of the filter dropdown, even though no options are selected 
- The previously selected option is still missing from the dropdown 
- Selecting a new option makes the previously removed option reappear

Fix:
Set the missing `value` prop on the `Select` component. Now the `Select` component always reflects the correct `value` array.