### PR TITLE
Rounded pronounced buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Button/Button.spec.tsx
+++ b/src/Button/Button.spec.tsx
@@ -57,6 +57,26 @@ describe('Input', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('roundedPronounced', () => {
+    const instance = renderer.create(
+      <Button name="default" variant="roundedPronounced">
+        default
+      </Button>,
+    )
+    const tree = instance.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('roundedPronouncedShadow', () => {
+    const instance = renderer.create(
+      <Button name="default" variant="roundedPronounced">
+        default
+      </Button>,
+    )
+    const tree = instance.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
   test('style overrides', () => {
     const instance = renderer.create(
       <Button name="override-a" styles={{ height: '100px', background: 'red' }}>

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -15,7 +15,15 @@ export default {
       control: {
         type: 'select',
       },
-      options: [null, 'rounded', 'square', 'roundedShadow', 'squareShadow'],
+      options: [
+        null,
+        'rounded',
+        'square',
+        'roundedShadow',
+        'squareShadow',
+        'roundedPronounced',
+        'roundedPronouncedShadow',
+      ],
     },
   },
 }

--- a/src/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/Button/__snapshots__/Button.spec.tsx.snap
@@ -46,6 +46,48 @@ exports[`Input rounded 1`] = `
 </button>
 `;
 
+exports[`Input roundedPronounced 1`] = `
+.c0 {
+  height: 30px;
+  cursor: pointer;
+  border: 1px solid #000;
+  padding: 0px 15px;
+  background: #fff;
+}
+
+.c1 {
+  border-radius: 4em;
+}
+
+<button
+  className="c0 c1"
+  name="default"
+>
+  default
+</button>
+`;
+
+exports[`Input roundedPronouncedShadow 1`] = `
+.c0 {
+  height: 30px;
+  cursor: pointer;
+  border: 1px solid #000;
+  padding: 0px 15px;
+  background: #fff;
+}
+
+.c1 {
+  border-radius: 4em;
+}
+
+<button
+  className="c0 c1"
+  name="default"
+>
+  default
+</button>
+`;
+
 exports[`Input roundedShadow 1`] = `
 .c0 {
   height: 30px;

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -65,7 +65,7 @@ const SquareButton = styled.button`
 `
 
 const RoundedButton = styled(SquareButton)`
-  border-radius: 0.6em;
+  border-radius: 8px;
 `
 
 const SquareShadowButton = styled(SquareButton)`

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
 
-type buttonVariant = 'rounded' | 'square' | 'roundedShadow' | 'squareShadow'
+type buttonVariant =
+  | 'rounded'
+  | 'square'
+  | 'roundedShadow'
+  | 'squareShadow'
+  // NEW
+  | 'roundedPronounced'
+  | 'roundedPronouncedShadow'
 
 export type ButtonTextProps = {
   styles?: React.CSSProperties
@@ -24,15 +31,23 @@ const ButtonBasic: React.FC<React.PropsWithChildren<ButtonTextProps>> = ({
     case 'rounded':
       Button = RoundedButton
       break
-    case 'roundedShadow':
-      Button = RoundedShadowButton
-      break
     case 'square':
       Button = SquareButton
+      break
+    case 'roundedShadow':
+      Button = RoundedShadowButton
       break
     case 'squareShadow':
       Button = SquareShadowButton
       break
+    // NEW
+    case 'roundedPronounced':
+      Button = RoundedPronouncedButton
+      break
+    case 'roundedPronouncedShadow':
+      Button = RoundedPronouncedShadowButton
+      break
+
     default:
       Button = RoundedShadowButton
       break
@@ -49,15 +64,25 @@ const SquareButton = styled.button`
   background: #fff;
 `
 
+const RoundedButton = styled(SquareButton)`
+  border-radius: 0.6em;
+`
+
 const SquareShadowButton = styled(SquareButton)`
   box-shadow: 0px 2px 0px 0px #000;
 `
 
-const RoundedButton = styled(SquareButton)`
-  border-radius: 8px;
+const RoundedShadowButton = styled(RoundedButton)`
+  box-shadow: 0px 2px 0px 0px #000;
 `
 
-const RoundedShadowButton = styled(RoundedButton)`
+// NEW
+
+const RoundedPronouncedButton = styled(SquareButton)`
+  border-radius: 4em;
+`
+
+const RoundedPronouncedShadowButton = styled(RoundedPronouncedButton)`
   box-shadow: 0px 2px 0px 0px #000;
 `
 


### PR DESCRIPTION
---
name: Rounded pronounced buttons
about: Rounded pronounced buttons new btn style
---

## Summary

Rounded pronounced buttons as in the roundness is very pronounced, meaning the left and right side of a buttons looks like a semicircle.

## Motivation

For our new design

## Describe alternatives you've considered

Other naming conventions have been considered

## Additional context

Example:

![image](https://github.com/digicatapult/ui-component-library/assets/58742260/1124224a-3c24-4e93-9abd-1497fc31595d)

---
