### PR TITLE
HYP-112: removing box-shaodw from hyproof variant and test case to ba…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Navigation/SidePanel/SidePanel.spec.tsx
+++ b/src/Navigation/SidePanel/SidePanel.spec.tsx
@@ -7,9 +7,10 @@ import SidePanel from './index.js'
 describe('SidePanel', () => {
   test('default', () => {
     const instance = renderer.create(
-      <SidePanel heading={'test heading'}>
+      <SidePanel variant='default' heading={'test heading'}>
         <SidePanel.Item
           update={(name) => window.alert(name)}
+          variant='default'
           name="unit"
           background="green"
           title="test no sub"
@@ -17,6 +18,31 @@ describe('SidePanel', () => {
         <SidePanel.Item
           update={(name) => window.alert(name)}
           name="test"
+          variant='default'
+          background="red"
+          title="test-tittle suite"
+          subtitle="this is subtitle"
+        />
+      </SidePanel>,
+    )
+    const tree = instance.toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+  test('hyproof', () => {
+    const instance = renderer.create(
+      <SidePanel variant='hyproof' heading={'test heading'}>
+        <SidePanel.Item
+          update={(name) => window.alert(name)}
+          variant='hyproof'
+          name="unit"
+          background="green"
+          title="test no sub"
+        />
+        <SidePanel.Item
+          update={(name) => window.alert(name)}
+          name="test"
+          variant='hyproof'
           background="red"
           title="test-tittle suite"
           subtitle="this is subtitle"

--- a/src/Navigation/SidePanel/SidePanel.spec.tsx
+++ b/src/Navigation/SidePanel/SidePanel.spec.tsx
@@ -7,10 +7,10 @@ import SidePanel from './index.js'
 describe('SidePanel', () => {
   test('default', () => {
     const instance = renderer.create(
-      <SidePanel variant='default' heading={'test heading'}>
+      <SidePanel variant="default" heading={'test heading'}>
         <SidePanel.Item
           update={(name) => window.alert(name)}
-          variant='default'
+          variant="default"
           name="unit"
           background="green"
           title="test no sub"
@@ -18,7 +18,7 @@ describe('SidePanel', () => {
         <SidePanel.Item
           update={(name) => window.alert(name)}
           name="test"
-          variant='default'
+          variant="default"
           background="red"
           title="test-tittle suite"
           subtitle="this is subtitle"
@@ -31,10 +31,10 @@ describe('SidePanel', () => {
   })
   test('hyproof', () => {
     const instance = renderer.create(
-      <SidePanel variant='hyproof' heading={'test heading'}>
+      <SidePanel variant="hyproof" heading={'test heading'}>
         <SidePanel.Item
           update={(name) => window.alert(name)}
-          variant='hyproof'
+          variant="hyproof"
           name="unit"
           background="green"
           title="test no sub"
@@ -42,7 +42,7 @@ describe('SidePanel', () => {
         <SidePanel.Item
           update={(name) => window.alert(name)}
           name="test"
-          variant='hyproof'
+          variant="hyproof"
           background="red"
           title="test-tittle suite"
           subtitle="this is subtitle"

--- a/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -103,6 +103,7 @@ exports[`SidePanel default 1`] = `
   style={
     {
       "isOpen": false,
+      "variant": "default",
       "width": undefined,
     }
   }
@@ -113,6 +114,7 @@ exports[`SidePanel default 1`] = `
     style={
       {
         "isOpen": false,
+        "variant": "default",
         "width": undefined,
       }
     }
@@ -183,6 +185,268 @@ exports[`SidePanel default 1`] = `
       <span>
         this is subtitle
       </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`SidePanel hyproof 1`] = `
+.c2 {
+  color: #4a4a4a;
+  font-family: Roboto;
+  margin-bottom: 100px;
+  max-width: 80%;
+  font-size: 30px;
+  line-height: 45px;
+}
+
+.c1 {
+  position: relative;
+  margin-left: 20px;
+  transition: all 0.5s ease-out-in;
+  top: 10%;
+  left: 300px;
+  cursor: pointer;
+}
+
+.c3 {
+  transition: all 0.3s ease-out;
+}
+
+.c3:hover {
+  opacity: 0.7;
+}
+
+.c0 {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding: 5px 25px;
+  width: 300px;
+  height: 0px;
+  left: -NaNpx;
+  top: 0px;
+  box-shadow: none;
+  transition: all 0.7s ease-in-out;
+}
+
+.c4 {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  background: #d9d9d9;
+  border: none;
+  border-radius: 60px;
+  margin: 5px;
+  padding: 8px;
+}
+
+.c6 {
+  background: inherit;
+  border: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  width: 100%;
+  height: 60px;
+  padding-left: calc(1em * 41 / (16 * 1.2));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5em;
+  border-top-left-radius: 0.75em;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0.75em;
+}
+
+.c6 >* {
+  display: block;
+  padding: 0;
+  margin: 0;
+  width: 90%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.c6 >label {
+  font-size: 1.2em;
+  font-weight: bolder;
+}
+
+.c6 >span {
+  font-size: 1em;
+}
+
+.c6::before {
+  content: '';
+  position: absolute;
+  display: none;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: unset;
+  width: 1em;
+  background: #e0e0e0;
+}
+
+.c6:focus-visible {
+  outline: 1px #e0e0e0 solid;
+}
+
+.c5 {
+  box-sizing: border-box;
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  width: 70px;
+  font-size: calc(70px / 4);
+  text-transform: uppercase;
+  aspect-ratio: 1/1;
+  border-radius: 50%;
+  border: calc(70px * 0.065) solid white;
+  background: green;
+}
+
+.c7 {
+  box-sizing: border-box;
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  width: 70px;
+  font-size: calc(70px / 4);
+  text-transform: uppercase;
+  aspect-ratio: 1/1;
+  border-radius: 50%;
+  border: calc(70px * 0.065) solid white;
+  background: red;
+}
+
+<div
+  className="c0"
+  onAnimationEnd={[Function]}
+  style={
+    {
+      "isOpen": false,
+      "variant": "hyproof",
+      "width": undefined,
+    }
+  }
+>
+  <div
+    className="c1"
+    onClick={[Function]}
+    style={
+      {
+        "isOpen": false,
+        "variant": "hyproof",
+        "width": undefined,
+      }
+    }
+  >
+    <svg
+      fill="none"
+      height="20"
+      viewBox="0 0 22 25"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0.499998 0L10.5 -1.74845e-06C16.8513 -2.85895e-06 22 5.14872 22 11.5L22 13.4677C22 19.819 16.8513 24.9677 10.5 24.9677L0.500002 24.9677L0.499998 0Z"
+        fill="#686867"
+        opacity="0.8"
+      />
+      <path
+        d="M7.0193 7.4903L11.9435 11.4297C12.6191 11.9701 12.6191 12.9976 11.9435 13.538L7.0193 17.4774"
+        stroke="white"
+        strokeLinecap="round"
+        strokeWidth="0.9"
+      />
+    </svg>
+  </div>
+  <div
+    className="c2"
+  >
+    test heading (undefined)
+  </div>
+  <div
+    className="c3"
+  >
+    <button
+      className="c4 hyproof"
+      onClick={[Function]}
+    >
+      <div
+        bgColor="green"
+        className="c5"
+        fullName="unit"
+        outlineColor="white"
+        size="70px"
+      >
+        <p>
+          u
+        </p>
+      </div>
+      <button
+        background="inherit"
+        className="c6"
+        flashColor="#e0e0e0"
+        height="60px"
+        id="id3"
+        orientation="left"
+        variant="hyproof"
+        width="100%"
+      >
+        <label
+          htmlFor="id3"
+        >
+          test no sub
+        </label>
+      </button>
+    </button>
+  </div>
+  <div
+    className="c3"
+  >
+    <button
+      className="c4 hyproof"
+      onClick={[Function]}
+    >
+      <div
+        bgColor="red"
+        className="c7"
+        fullName="test"
+        outlineColor="white"
+        size="70px"
+      >
+        <p>
+          t
+        </p>
+      </div>
+      <button
+        background="inherit"
+        className="c6"
+        flashColor="#e0e0e0"
+        height="60px"
+        id="id4"
+        orientation="left"
+        variant="hyproof"
+        width="100%"
+      >
+        <label
+          htmlFor="id4"
+        >
+          test-tittle suite
+        </label>
+        <span>
+          this is subtitle
+        </span>
+      </button>
     </button>
   </div>
 </div>

--- a/src/Navigation/SidePanel/common.tsx
+++ b/src/Navigation/SidePanel/common.tsx
@@ -38,6 +38,6 @@ export const Panel = styled('div')`
   left: ${({ style: { isOpen, width } }: any) =>
     isOpen ? '0px' : `-${width + 50}px`};
   top: 0px;
-  box-shadow: 0px 4px 5px rgba(0, 0, 0, 0.1);
+  box-shadow: ${({ style: { variant }}: any) => variant === 'default' ? '0px 4px 5px rgba(0, 0, 0, 0.1)' : 'none'};
   transition: all 0.7s ease-in-out;
 `

--- a/src/Navigation/SidePanel/common.tsx
+++ b/src/Navigation/SidePanel/common.tsx
@@ -38,6 +38,7 @@ export const Panel = styled('div')`
   left: ${({ style: { isOpen, width } }: any) =>
     isOpen ? '0px' : `-${width + 50}px`};
   top: 0px;
-  box-shadow: ${({ style: { variant }}: any) => variant === 'default' ? '0px 4px 5px rgba(0, 0, 0, 0.1)' : 'none'};
+  box-shadow: ${({ style: { variant } }: any) =>
+    variant === 'default' ? '0px 4px 5px rgba(0, 0, 0, 0.1)' : 'none'};
   transition: all 0.7s ease-in-out;
 `

--- a/src/Navigation/SidePanel/index.tsx
+++ b/src/Navigation/SidePanel/index.tsx
@@ -67,7 +67,11 @@ const SidePanel: ISidePanel & IItem = ({
 }) => {
   const [show, setShow] = React.useState(false)
 
-  const style = { variant: props.variant, width: props.width, isOpen: show } as React.CSSProperties
+  const style = {
+    variant: props.variant,
+    width: props.width,
+    isOpen: show,
+  } as React.CSSProperties
   return (
     <Panel onAnimationEnd={() => setShow(true)} style={style}>
       <Button

--- a/src/Navigation/SidePanel/index.tsx
+++ b/src/Navigation/SidePanel/index.tsx
@@ -8,7 +8,7 @@ import Avatar from '../../UserIcon/index.js'
 export interface SidePanelProps {
   heading?: string
   title?: string
-  variant?: 'default' | 'hyproof'
+  variant: 'default' | 'hyproof'
   width?: string
   isOpen?: boolean
   callback?: (data: { [k: string]: string | number | boolean }) => void
@@ -67,7 +67,7 @@ const SidePanel: ISidePanel & IItem = ({
 }) => {
   const [show, setShow] = React.useState(false)
 
-  const style = { width: props.width, isOpen: show } as React.CSSProperties
+  const style = { variant: props.variant, width: props.width, isOpen: show } as React.CSSProperties
   return (
     <Panel onAnimationEnd={() => setShow(true)} style={style}>
       <Button


### PR DESCRIPTION
# What

A simple PR before making a final on HYP-112. 

Changes:
- leaving box shadow only for default variant
- test scenario to cover hyporoof variant


### Screenshot
<img width="445" alt="Screenshot 2024-02-05 at 11 46 23 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/941c86eb-a04c-4b7d-87c7-92ac3a8a15cc">

<img width="438" alt="Screenshot 2024-02-05 at 11 46 29 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/c46ca6da-f155-4cc4-8241-a01788405b14">
