### PR TITLE
HYP-117: avatar is round and panels button position changed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/ListCard/index.tsx
+++ b/src/ListCard/index.tsx
@@ -12,6 +12,7 @@ export interface ListCardProps {
   width?: string
   background?: string
   variant?: 'default' | 'hyproof'
+  id?: string
   Icon?: React.FC | typeof Avatar
   height?: string
   onClick: (title: string) => void
@@ -86,8 +87,11 @@ const ListCard = React.forwardRef<HTMLButtonElement, ListCardProps>(
 const Row = styled('button')`
   display: flex;
   flex-direction: row;
-  width: 100%;
+  align-items: center;
+  justify-content: flex-start;
   background: #d9d9d9;
+  box-sizing: content-box;
+  width: 90%;
   overflow: hidden;
   border: none;
   border-radius: ${({ className }: any) => {
@@ -107,11 +111,11 @@ const Wrapper = styled('button')<WrapperProps>`
   font: inherit;
   text-align: ${({ orientation }) => orientation};
   cursor: pointer;
-
   position: relative;
-  width: ${({ width }) => width};
-  height: ${({ height }) => height};
-  padding-left: calc(1em * 41 / (16 * 1.2));
+  width: ${({ width, variant }) => (variant === 'hyproof' ? '80%' : width)};
+  height: ${({ height, variant }) => (variant === 'hyproof' ? '' : height)};
+  padding-left: ${({ variant }) =>
+    variant === 'hyproof' ? '10px' : 'calc(1em * 41 / (16 * 1.2))'};
   overflow: hidden;
 
   display: flex;

--- a/src/ListCard/index.tsx
+++ b/src/ListCard/index.tsx
@@ -12,7 +12,6 @@ export interface ListCardProps {
   width?: string
   background?: string
   variant?: 'default' | 'hyproof'
-  id?: string
   Icon?: React.FC | typeof Avatar
   height?: string
   onClick: (title: string) => void

--- a/src/Navigation/SidePanel/SidePanel.stories.tsx
+++ b/src/Navigation/SidePanel/SidePanel.stories.tsx
@@ -28,15 +28,20 @@ export default {
 }
 
 const DefaultStoryTemplate = (args: SidePanelProps) => {
-  const [current, setCurrent] = React.useState({})
+  const [items] = React.useState(fixtures[args.variant || 'default'])
+  const [current, setCurrent] = React.useState({
+    current: 'heidi',
+    title: 'Heidi Heidi',
+  })
 
   return (
     <SidePanel {...args} {...current} callback={action('open')}>
-      {fixtures[args.variant || 'default'].map((item) => (
+      {items.map((item) => (
         <SidePanel.Item
+          active={current === item.title || false}
           {...args}
           update={(name, persona) => {
-            setCurrent({ current: name, ...persona })
+            setCurrent({ current: name || '', ...persona })
           }}
           key={item.name}
           {...item}
@@ -56,6 +61,6 @@ Default.args = {
 export const HyProof = DefaultStoryTemplate.bind({})
 HyProof.args = {
   variant: 'hyproof',
-  heading: 'HyProof Certificate Viewing',
+  heading: 'HyProof Variant',
   width: 400,
 }

--- a/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`SidePanel default 1`] = `
   transition: all 0.5s ease-out-in;
   top: 10%;
   left: 300px;
+  animation: indicate 1s infinite;
   cursor: pointer;
 }
 
@@ -24,14 +25,14 @@ exports[`SidePanel default 1`] = `
 }
 
 .c3:hover {
-  opacity: 0.5;
+  opacity: 0.7;
 }
 
 .c0 {
   position: absolute;
   display: flex;
   flex-direction: column;
-  gap: 1em;
+  gap: 0.2em;
   padding: 5px 25px;
   width: 300px;
   height: 0px;
@@ -216,6 +217,7 @@ exports[`SidePanel hyproof 1`] = `
   transition: all 0.5s ease-out-in;
   top: 10%;
   left: 300px;
+  animation: indicate 1s infinite;
   cursor: pointer;
 }
 
@@ -224,14 +226,14 @@ exports[`SidePanel hyproof 1`] = `
 }
 
 .c3:hover {
-  opacity: 0.5;
+  opacity: 0.7;
 }
 
 .c0 {
   position: absolute;
   display: flex;
   flex-direction: column;
-  gap: 1em;
+  gap: 0.2em;
   padding: 5px 25px;
   width: 300px;
   height: 0px;
@@ -244,8 +246,11 @@ exports[`SidePanel hyproof 1`] = `
 .c4 {
   display: flex;
   flex-direction: row;
-  width: 100%;
+  align-items: center;
+  justify-content: flex-start;
   background: #d9d9d9;
+  box-sizing: content-box;
+  width: 90%;
   overflow: hidden;
   border: none;
   border-radius: 60px;
@@ -259,9 +264,8 @@ exports[`SidePanel hyproof 1`] = `
   text-align: left;
   cursor: pointer;
   position: relative;
-  width: 100%;
-  height: 60px;
-  padding-left: calc(1em * 41 / (16 * 1.2));
+  width: 80%;
+  padding-left: 10px;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/src/Navigation/SidePanel/common.tsx
+++ b/src/Navigation/SidePanel/common.tsx
@@ -17,13 +17,23 @@ export const Button = styled('div')`
   transition: all 0.5s ease-out-in;
   top: 10%;
   left: ${({ style: { width } }: any) => width || 300}px;
+  animation: indicate 1s infinite;
+
+  @keyframes indicate {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0.3;
+    }
+  }
   cursor: pointer;
 `
 
 export const ItemWrapper = styled('div')`
   transition: all 0.3s ease-out;
   &:hover {
-    opacity: 0.5;
+    opacity: 0.7;
   }
 `
 
@@ -31,7 +41,7 @@ export const Panel = styled('div')`
   position: absolute;
   display: flex;
   flex-direction: column;
-  gap: 1em;
+  gap: 0.2em;
   padding: 5px 25px;
   width: ${({ style: { width } }: any) => width || 300}px;
   height: ${viewPortH}px;


### PR DESCRIPTION
# What

Mainly addressing a couple bugs for `hyproof` variant

### fixes:
- avatar is round
- arrow was outside of panel borders, moved to be inside when it's open - please refer to a screenshot below
- added indicator (opacity) for the arrow

### screenshots
<img width="95" alt="Screenshot 2024-02-07 at 11 26 34 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/fc0187f1-4cbe-4d2a-905b-c43a35e4df0f">
<img width="129" alt="Screenshot 2024-02-07 at 11 26 33 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/f9175914-2d53-45ee-8a04-bcc553156779">
<img width="612" alt="Screenshot 2024-02-07 at 11 17 10 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/c0b3cbc0-a07c-4e5e-982a-fe243cd7907e">
<img width="527" alt="Screenshot 2024-02-07 at 11 16 47 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/e8c0cb8f-78fd-4fbd-8f08-9c518b755189">
<img width="596" alt="Screenshot 2024-02-07 at 11 04 29 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/aba9bb53-bec9-447c-a992-7cd6b254692a">


