### PR TITLE
HYP-133: removing padding as it was causing some layout issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.17.31",
+  "version": "0.17.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.17.31",
+      "version": "0.17.32",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.17.31",
+  "version": "0.17.32",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Table/__snapshots__/Table.spec.tsx.snap
+++ b/src/Table/__snapshots__/Table.spec.tsx.snap
@@ -9,18 +9,20 @@ exports[`Table default 1`] = `
 .c3:before {
   content: '';
   position: absolute;
-  right: 36px;
+  right: 0;
   border-bottom: 15px solid #eee;
   border-right: 15px solid #27847a;
 }
 
 .c1 {
+  position: relative;
+  box-sizing: border-box;
+  border: 5px solid transparent;
   width: 100%;
 }
 
 .c0 {
   background-color: #27847a;
-  padding: 20px;
 }
 
 <div
@@ -352,18 +354,20 @@ exports[`Table hyproof 1`] = `
 .c3:before {
   content: '';
   position: absolute;
-  right: 36px;
+  right: 0;
   border-bottom: 15px solid #eee;
   border-right: 15px solid #27847a;
 }
 
 .c1 {
+  position: relative;
+  box-sizing: border-box;
+  border: 5px solid transparent;
   width: 100%;
 }
 
 .c0 {
   background-color: #27847a;
-  padding: 20px;
 }
 
 .c6 {

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -59,21 +59,22 @@ const TR = styled('tr')`
     position: absolute;
     ${(props) =>
       props.color === 'not-page' &&
-      `
-  right: 36px;
-  border-bottom: 15px solid #eee;
-  border-right: 15px solid #27847a`};
+      `right: 0;
+      border-bottom: 15px solid #eee;
+      border-right: 15px solid #27847a`};
   }
 `
 
 const Wrapper = styled('table')<TableProps>`
+  position: relative;
+  box-sizing: border-box;
+  border: 5px solid transparent;
   width: ${({ width }) => width || '100%'};
 `
 
 const Background = styled('div')`
   background-color: ${(props) =>
     props.color === 'hyproof' ? '#27847a' : 'none'};
-  padding: 20px;
 `
 
 export default Table


### PR DESCRIPTION
# What

In some browser e.g. firefox page corner was not rendering correctly due to padding, and offset by right which should have been `0`.. Before 

> before
![image (2)](https://github.com/digicatapult/ui-component-library/assets/11794402/30ac06cb-490a-49f0-88ea-d4be05ea65a2)

> after
<img width="799" alt="Screenshot 2024-03-05 at 9 04 09 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/8533382a-c7b3-4c53-9207-886cbe0e0634">
<img width="573" alt="Screenshot 2024-03-05 at 9 04 02 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/2b1399a2-9cae-4d33-bcd9-6a2ff841db8e">
<img width="1499" alt="Screenshot 2024-03-05 at 9 03 51 am" src="https://github.com/digicatapult/ui-component-library/assets/11794402/4727472e-2b9a-4132-b754-2cb33b595d92">
