### PR TITLE
Chore/panel improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Navigation/SidePanel/SidePanel.stories.tsx
+++ b/src/Navigation/SidePanel/SidePanel.stories.tsx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions'
 
 import SidePanel, { SidePanelProps } from './index.js'
 import { hyproof, basic } from './fixtures.js'
+import { styled } from 'styled-components'
 
 const fixtures = { hyproof, default: basic }
 
@@ -53,12 +54,14 @@ export const Default = DefaultStoryTemplate.bind({})
 Default.args = {
   variant: 'default',
   heading: 'Basic Side Panel',
-  width: 300,
+  width: '300px',
+  isOpen: true,
 }
 
 export const HyProof = DefaultStoryTemplate.bind({})
 HyProof.args = {
   variant: 'hyproof',
   heading: 'HyProof Variant',
-  width: 400,
+  width: '400px',
+  isOpen: true,
 }

--- a/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -11,11 +11,13 @@ exports[`SidePanel default 1`] = `
 }
 
 .c1 {
-  position: relative;
-  margin-left: 20px;
+  position: absolute;
   top: 10%;
-  left: 300px;
+  right: 0px;
   cursor: pointer;
+  transform: scaleX(1) translateX(100%);
+  transform-origin: 100%;
+  transition: transform 0.7s ease-in-out;
 }
 
 .c3 {
@@ -28,16 +30,18 @@ exports[`SidePanel default 1`] = `
 
 .c0 {
   position: absolute;
+  box-sizing: border-box;
+  width: 300px;
+  height: 100lvh;
+  left: 0px;
+  top: 0px;
   display: flex;
   flex-direction: column;
   gap: 0.2em;
   padding: 5px 25px;
-  width: 300px;
-  height: 0px;
-  left: -NaNpx;
-  top: 0px;
+  transform: translateX(     -300px   );
+  transition: transform 0.7s ease-in-out;
   box-shadow: 0px 4px 5px rgba(0, 0, 0, 0.1);
-  transition: all 0.7s ease-in-out;
 }
 
 .c4 {
@@ -155,24 +159,12 @@ exports[`SidePanel default 1`] = `
 <div
   className="c0"
   onAnimationEnd={[Function]}
-  style={
-    {
-      "isOpen": false,
-      "variant": "default",
-      "width": undefined,
-    }
-  }
+  variant="default"
 >
   <div
     className="c1"
     onClick={[Function]}
-    style={
-      {
-        "isOpen": false,
-        "variant": "default",
-        "width": undefined,
-      }
-    }
+    variant="default"
   >
     <svg
       fill="none"
@@ -246,7 +238,7 @@ exports[`SidePanel default 1`] = `
 `;
 
 exports[`SidePanel hyproof 1`] = `
-.c2 {
+.c3 {
   color: #4a4a4a;
   font-family: Roboto;
   margin-bottom: 100px;
@@ -255,37 +247,47 @@ exports[`SidePanel hyproof 1`] = `
   line-height: 45px;
 }
 
-.c1 {
-  position: relative;
-  margin-left: 20px;
+.c2 {
+  position: absolute;
   top: 10%;
-  left: 300px;
+  right: 0px;
   cursor: pointer;
+  transform: scaleX(1) translateX(100%);
+  transform-origin: 100%;
+  transition: transform 0.7s ease-in-out;
 }
 
-.c3 {
+.c4 {
   transition: all 0.3s ease-out;
 }
 
-.c3:hover {
+.c4:hover {
   opacity: 0.7;
 }
 
 .c0 {
   position: absolute;
+  box-sizing: border-box;
+  width: 300px;
+  height: 100lvh;
+  left: 0px;
+  top: 0px;
   display: flex;
   flex-direction: column;
   gap: 0.2em;
   padding: 5px 25px;
-  width: 300px;
-  height: 0px;
-  left: -NaNpx;
-  top: 0px;
-  box-shadow: none;
-  transition: all 0.7s ease-in-out;
+  transform: translateX(     -300px   );
+  transition: transform 0.7s ease-in-out;
+  box-shadow: 0px 4px 5px rgba(0, 0, 0, 0.1);
 }
 
-.c4 {
+.c1 {
+  box-shadow: none;
+  background: rgba(255, 255, 255, 80%);
+  backdrop-filter: blur(10px);
+}
+
+.c5 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -299,7 +301,7 @@ exports[`SidePanel hyproof 1`] = `
   padding: 5px;
 }
 
-.c6 {
+.c7 {
   border: 0;
   font: inherit;
   background: inherit;
@@ -319,7 +321,7 @@ exports[`SidePanel hyproof 1`] = `
   border-bottom-left-radius: 0.75em;
 }
 
-.c6 >* {
+.c7 >* {
   display: block;
   padding: 0;
   margin: 0;
@@ -330,16 +332,16 @@ exports[`SidePanel hyproof 1`] = `
   cursor: pointer;
 }
 
-.c6 >label {
+.c7 >label {
   font-size: 1.2em;
   font-weight: bolder;
 }
 
-.c6 >span {
+.c7 >span {
   font-size: 1em;
 }
 
-.c6::before {
+.c7::before {
   content: '';
   position: absolute;
   display: none;
@@ -351,11 +353,11 @@ exports[`SidePanel hyproof 1`] = `
   background: green;
 }
 
-.c6:focus-visible {
+.c7:focus-visible {
   outline: 1px green solid;
 }
 
-.c8 {
+.c9 {
   border: 0;
   font: inherit;
   background: inherit;
@@ -375,7 +377,7 @@ exports[`SidePanel hyproof 1`] = `
   border-bottom-left-radius: 0.75em;
 }
 
-.c8 >* {
+.c9 >* {
   display: block;
   padding: 0;
   margin: 0;
@@ -386,16 +388,16 @@ exports[`SidePanel hyproof 1`] = `
   cursor: pointer;
 }
 
-.c8 >label {
+.c9 >label {
   font-size: 1.2em;
   font-weight: bolder;
 }
 
-.c8 >span {
+.c9 >span {
   font-size: 1em;
 }
 
-.c8::before {
+.c9::before {
   content: '';
   position: absolute;
   display: none;
@@ -407,11 +409,11 @@ exports[`SidePanel hyproof 1`] = `
   background: red;
 }
 
-.c8:focus-visible {
+.c9:focus-visible {
   outline: 1px red solid;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   display: grid;
   align-items: center;
@@ -425,7 +427,7 @@ exports[`SidePanel hyproof 1`] = `
   background: green;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   display: grid;
   align-items: center;
@@ -440,26 +442,14 @@ exports[`SidePanel hyproof 1`] = `
 }
 
 <div
-  className="c0"
+  className="c0 c1"
   onAnimationEnd={[Function]}
-  style={
-    {
-      "isOpen": false,
-      "variant": "hyproof",
-      "width": undefined,
-    }
-  }
+  variant="hyproof"
 >
   <div
-    className="c1"
+    className="c2"
     onClick={[Function]}
-    style={
-      {
-        "isOpen": false,
-        "variant": "hyproof",
-        "width": undefined,
-      }
-    }
+    variant="hyproof"
   >
     <svg
       fill="none"
@@ -482,22 +472,22 @@ exports[`SidePanel hyproof 1`] = `
     </svg>
   </div>
   <div
-    className="c2"
+    className="c3"
   >
     test heading (undefined)
   </div>
   <div
-    className="c3"
+    className="c4"
   >
     <button
       active={false}
       background="green"
-      className="c4 hyproof"
+      className="c5 hyproof"
       onClick={[Function]}
     >
       <div
         bgColor="green"
-        className="c5"
+        className="c6"
         fullName="unit"
         outlineColor="white"
         size="60px"
@@ -508,7 +498,7 @@ exports[`SidePanel hyproof 1`] = `
       </div>
       <button
         background="inherit"
-        className="c6"
+        className="c7"
         flashColor="green"
         height="60px"
         id="id3"
@@ -525,17 +515,17 @@ exports[`SidePanel hyproof 1`] = `
     </button>
   </div>
   <div
-    className="c3"
+    className="c4"
   >
     <button
       active={false}
       background="red"
-      className="c4 hyproof"
+      className="c5 hyproof"
       onClick={[Function]}
     >
       <div
         bgColor="red"
-        className="c7"
+        className="c8"
         fullName="test"
         outlineColor="white"
         size="60px"
@@ -546,7 +536,7 @@ exports[`SidePanel hyproof 1`] = `
       </div>
       <button
         background="inherit"
-        className="c8"
+        className="c9"
         flashColor="red"
         height="60px"
         id="id4"

--- a/src/Navigation/SidePanel/common.tsx
+++ b/src/Navigation/SidePanel/common.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
-
-const viewPortH: number = window.visualViewport?.height || 0
+import { SidePanelProps } from './index.js'
 
 export const Heading = styled('div')`
   color: #4a4a4a;
@@ -11,12 +10,14 @@ export const Heading = styled('div')`
   line-height: 45px;
 `
 
-export const Button = styled('div')`
-  position: relative;
-  margin-left: ${({ style: { isOpen } }: any) => (isOpen ? 5 : 20)}px;
+export const Button = styled.div<SidePanelProps>`
+  position: absolute;
   top: 10%;
-  left: ${({ style: { width } }: any) => width || 300}px;
+  right: 0px;
   cursor: pointer;
+  transform: scaleX(${({ isOpen }) => (isOpen ? '-1' : '1')}) translateX(100%);
+  transform-origin: 100%;
+  transition: transform 0.7s ease-in-out;
 `
 
 export const ItemWrapper = styled('div')`
@@ -26,18 +27,29 @@ export const ItemWrapper = styled('div')`
   }
 `
 
-export const Panel = styled('div')`
+export const DefaultPanel = styled.div<SidePanelProps>`
   position: absolute;
+  box-sizing: border-box;
+  width: ${({ width }) => width || '300px'};
+  height: 100lvh;
+  left: 0px;
+  top: 0px;
+
   display: flex;
   flex-direction: column;
   gap: 0.2em;
+
   padding: 5px 25px;
-  width: ${({ style: { width } }: any) => width || 300}px;
-  height: ${viewPortH}px;
-  left: ${({ style: { isOpen, width } }: any) =>
-    isOpen ? '0px' : `-${width + 50}px`};
-  top: 0px;
-  box-shadow: ${({ style: { variant } }: any) =>
-    variant === 'default' ? '0px 4px 5px rgba(0, 0, 0, 0.1)' : 'none'};
-  transition: all 0.7s ease-in-out;
+  transform: translateX(
+    ${({ isOpen, width }) => (isOpen ? '0px' : `-${width || '300px'}`)}
+  );
+  transition: transform 0.7s ease-in-out;
+
+  box-shadow: 0px 4px 5px rgba(0, 0, 0, 0.1);
+`
+
+export const HiiVariantPanel = styled(DefaultPanel)<SidePanelProps>`
+  box-shadow: none;
+  background: rgba(255, 255, 255, 80%);
+  backdrop-filter: blur(10px);
 `

--- a/src/Navigation/SidePanel/index.tsx
+++ b/src/Navigation/SidePanel/index.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 
-import { Heading, Button, Panel, ItemWrapper } from './common.js'
+import {
+  Heading,
+  Button,
+  DefaultPanel,
+  HiiVariantPanel,
+  ItemWrapper,
+} from './common.js'
 import ListCard, { ListCardProps } from '../../ListCard/index.js'
-import { SideArrowCloseIcon, SideArrowOpenIcon } from '../../index.js'
+import { SideArrowCloseIcon } from '../../index.js'
 import Avatar from '../../UserIcon/index.js'
 
 export interface SidePanelProps {
@@ -12,8 +18,7 @@ export interface SidePanelProps {
   width?: string
   isOpen?: boolean
   active?: boolean
-  callback?: (data: { [k: string]: string | number | boolean }) => void
-  update?: (name: string, persona: Persona, e?: MouseEvent) => void
+  callback?: (data: { isOpen: boolean }) => void
 }
 
 export interface SidePanelItemProps extends SidePanelProps {
@@ -23,13 +28,16 @@ export interface SidePanelItemProps extends SidePanelProps {
   active?: boolean
   color?: string
   subtitle?: string
+  update?: (name: string, persona: Persona, e?: MouseEvent) => void
 }
 
 interface IItem {
   Item: typeof Item
 }
 type Persona = Omit<ListCardProps, 'onClick'>
-type ISidePanel = React.FC<React.PropsWithChildren<SidePanelProps>>
+type ISidePanel = React.FC<
+  React.PropsWithChildren<SidePanelProps> & React.HTMLAttributes<HTMLDivElement>
+>
 
 const Item: React.FC<React.PropsWithChildren<SidePanelItemProps>> = ({
   update = () => {},
@@ -65,30 +73,35 @@ const Item: React.FC<React.PropsWithChildren<SidePanelItemProps>> = ({
 
 const SidePanel: ISidePanel & IItem = ({
   children,
-  update,
+  className,
   callback,
   heading,
   ...props
 }) => {
-  const [show, setShow] = React.useState(false)
+  const { variant, isOpen, width, title } = props
+  const [show, setShow] = React.useState(isOpen)
 
-  const style = {
-    variant: props.variant,
-    width: props.width,
-    isOpen: show,
-  } as React.CSSProperties
+  const Panel = variant === 'default' ? DefaultPanel : HiiVariantPanel
+
   return (
-    <Panel onAnimationEnd={() => setShow(true)} style={style}>
+    <Panel
+      onAnimationEnd={() => setShow(true)}
+      variant={variant}
+      isOpen={show}
+      width={width}
+      className={className}
+    >
       <Button
         onClick={() => {
           setShow(!show)
-          if (callback) return callback({ ...props, isOpen: !show })
+          if (callback) return callback({ isOpen: !show })
         }}
-        style={style}
+        {...props}
+        isOpen={show}
       >
-        {show ? <SideArrowOpenIcon /> : <SideArrowCloseIcon />}
+        <SideArrowCloseIcon />
       </Button>
-      <Heading>{`${heading} (${props.title})`}</Heading>
+      <Heading>{`${heading} (${title})`}</Heading>
       {children}
     </Panel>
   )


### PR DESCRIPTION
The following improvements have been made to the panel element:

1. Panel is now styld so it will only take up 100% of the viewport height
2. transitions now only use transform so will be more efficient (note this is breaking because the panel will now overlay content rather than shift it)
3. Hii Panel varient has a background with blured content
4. props are now handled correctly
5. styles can now be applied externally


https://github.com/digicatapult/ui-component-library/assets/29942957/7095a75f-7bb1-4a46-9899-538b4fe53fea

Example demonstrating blur (not included in sb)

https://github.com/digicatapult/ui-component-library/assets/29942957/f0a1c01e-07c4-4344-b9e3-920161c8ba97

