### PR TITLE
Chore/side panel improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -6,7 +6,6 @@ type buttonVariant =
   | 'square'
   | 'roundedShadow'
   | 'squareShadow'
-  // NEW
   | 'roundedPronounced'
   | 'roundedPronouncedShadow'
 
@@ -40,7 +39,6 @@ const ButtonBasic: React.FC<React.PropsWithChildren<ButtonTextProps>> = ({
     case 'squareShadow':
       Button = SquareShadowButton
       break
-    // NEW
     case 'roundedPronounced':
       Button = RoundedPronouncedButton
       break
@@ -75,8 +73,6 @@ const SquareShadowButton = styled(SquareButton)`
 const RoundedShadowButton = styled(RoundedButton)`
   box-shadow: 0px 2px 0px 0px #000;
 `
-
-// NEW
 
 const RoundedPronouncedButton = styled(SquareButton)`
   border-radius: 4em;

--- a/src/ListCard/__snapshots__/ListCard.spec.tsx.snap
+++ b/src/ListCard/__snapshots__/ListCard.spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`Test default 1`] = `
 .c0 {
+  background: inherit;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: left;
   cursor: pointer;
   position: relative;
@@ -77,9 +77,9 @@ exports[`Test default 1`] = `
 
 exports[`Test hii 1`] = `
 .c0 {
+  background: #DCE5E7;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: left;
   cursor: pointer;
   position: relative;
@@ -155,9 +155,9 @@ exports[`Test hii 1`] = `
 
 exports[`Test orientation: right 1`] = `
 .c0 {
+  background: #DCE5E7;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: right;
   cursor: pointer;
   position: relative;

--- a/src/ListCard/index.tsx
+++ b/src/ListCard/index.tsx
@@ -4,7 +4,10 @@ import { useId } from 'react-id-generator'
 
 import type Avatar from '../UserIcon/index.js'
 
+import type { HTMLAttributes } from 'react'
+
 export interface ListCardProps {
+  className?: HTMLAttributes<HTMLButtonElement>['className']
   title: string
   subtitle?: string
   orientation?: 'left' | 'right'
@@ -18,9 +21,10 @@ export interface ListCardProps {
   onClick: (title: string) => void
 }
 
-interface RowProps extends React.DOMAttributes<HTMLButtonElement> {
+interface RowProps extends React.HTMLAttributes<HTMLButtonElement> {
   active: boolean
   background: string
+  variant: 'default' | 'hyproof'
 }
 
 interface WrapperProps extends React.DOMAttributes<HTMLButtonElement> {
@@ -37,6 +41,7 @@ interface WrapperProps extends React.DOMAttributes<HTMLButtonElement> {
 const ListCard = React.forwardRef<HTMLButtonElement, ListCardProps>(
   (
     {
+      className,
       variant = 'default',
       active = false,
       flashColor = '#e0e0e0',
@@ -55,17 +60,18 @@ const ListCard = React.forwardRef<HTMLButtonElement, ListCardProps>(
     if (variant === 'hyproof')
       return (
         <Row
-          className={variant}
+          className={className}
+          variant={variant}
           onClick={() => onClick(title)}
           active={active}
-          background={flashColor}
+          background={active ? flashColor : '#d9d9d9'}
           ref={listCardRef}
         >
           {Icon && <Icon />}
           <Wrapper
             variant={variant}
             orientation={orientation}
-            background={background}
+            background={'inherit'}
             flashColor={flashColor}
             width={width}
             height={'60px'}
@@ -78,6 +84,7 @@ const ListCard = React.forwardRef<HTMLButtonElement, ListCardProps>(
       )
     return (
       <Wrapper
+        className={className}
         onClick={() => onClick(title)}
         orientation={orientation}
         background={background}
@@ -93,7 +100,7 @@ const ListCard = React.forwardRef<HTMLButtonElement, ListCardProps>(
   },
 )
 
-const Row = styled('button')<RowProps>`
+const Row = styled.button<RowProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -101,13 +108,11 @@ const Row = styled('button')<RowProps>`
   box-sizing: content-box;
   width: 90%;
   overflow: hidden;
-  background: ${({ background, active }) => {
-    if (active) return background
-    return '#d9d9d9'
-  }};
-  border: none;
-  border-radius: ${({ className }: any) => {
-    switch (className) {
+  background: ${({ background }) => background};
+  border: 2px solid
+    color-mix(in lab, ${({ background }) => background} 70%, black);
+  border-radius: ${({ variant }) => {
+    switch (variant) {
       case 'hyproof':
         return '60px'
       default:
@@ -117,10 +122,10 @@ const Row = styled('button')<RowProps>`
   padding: 5px;
 `
 
-const Wrapper = styled('button')<WrapperProps>`
+const Wrapper = styled.button<WrapperProps>`
+  background: ${({ background }) => background};
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: ${({ orientation }) => orientation};
   cursor: pointer;
   position: relative;

--- a/src/Navigation/SidePanel/SidePanel.stories.tsx
+++ b/src/Navigation/SidePanel/SidePanel.stories.tsx
@@ -39,7 +39,7 @@ const DefaultStoryTemplate = (args: SidePanelProps) => {
         <SidePanel.Item
           active={current === item.title || false}
           {...args}
-          update={(name, persona) => {
+          update={(name) => {
             setCurrent(name || '')
           }}
           key={item.name}

--- a/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -45,9 +45,9 @@ exports[`SidePanel default 1`] = `
 }
 
 .c4 {
+  background: inherit;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: left;
   cursor: pointer;
   position: relative;
@@ -101,9 +101,9 @@ exports[`SidePanel default 1`] = `
 }
 
 .c5 {
+  background: inherit;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: left;
   cursor: pointer;
   position: relative;
@@ -266,7 +266,7 @@ exports[`SidePanel hyproof 1`] = `
 }
 
 .c0 {
-  position: absolute;
+  position: fixed;
   box-sizing: border-box;
   width: 300px;
   height: 100lvh;
@@ -283,8 +283,8 @@ exports[`SidePanel hyproof 1`] = `
 
 .c1 {
   box-shadow: none;
-  background: rgba(255, 255, 255, 80%);
-  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 90%);
+  backdrop-filter: blur(5px);
 }
 
 .c5 {
@@ -296,15 +296,15 @@ exports[`SidePanel hyproof 1`] = `
   width: 90%;
   overflow: hidden;
   background: #d9d9d9;
-  border: none;
+  border: 2px solid color-mix(in lab, #d9d9d9 70%, black);
   border-radius: 60px;
   padding: 5px;
 }
 
 .c7 {
+  background: inherit;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: left;
   cursor: pointer;
   position: relative;
@@ -358,9 +358,9 @@ exports[`SidePanel hyproof 1`] = `
 }
 
 .c9 {
+  background: inherit;
   border: 0;
   font: inherit;
-  background: inherit;
   text-align: left;
   cursor: pointer;
   position: relative;
@@ -481,9 +481,10 @@ exports[`SidePanel hyproof 1`] = `
   >
     <button
       active={false}
-      background="green"
-      className="c5 hyproof"
+      background="#d9d9d9"
+      className="c5"
       onClick={[Function]}
+      variant="hyproof"
     >
       <div
         bgColor="green"
@@ -519,9 +520,10 @@ exports[`SidePanel hyproof 1`] = `
   >
     <button
       active={false}
-      background="red"
-      className="c5 hyproof"
+      background="#d9d9d9"
+      className="c5"
       onClick={[Function]}
+      variant="hyproof"
     >
       <div
         bgColor="red"

--- a/src/Navigation/SidePanel/common.tsx
+++ b/src/Navigation/SidePanel/common.tsx
@@ -28,7 +28,7 @@ export const ItemWrapper = styled('div')`
 `
 
 export const DefaultPanel = styled.div<SidePanelProps>`
-  position: absolute;
+  position: ${({ variant }) => (variant === 'hyproof' ? 'fixed' : 'absolute')};
   box-sizing: border-box;
   width: ${({ width }) => width || '300px'};
   height: 100lvh;
@@ -50,6 +50,6 @@ export const DefaultPanel = styled.div<SidePanelProps>`
 
 export const HiiVariantPanel = styled(DefaultPanel)<SidePanelProps>`
   box-shadow: none;
-  background: rgba(255, 255, 255, 80%);
-  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 90%);
+  backdrop-filter: blur(5px);
 `

--- a/src/Timeline/__snapshots__/Timeline.spec.tsx.snap
+++ b/src/Timeline/__snapshots__/Timeline.spec.tsx.snap
@@ -42,15 +42,10 @@ exports[`Timeline default renders basic Timeline with a single Timeline.Item 1`]
   color: #a7a7a7;
   font-size: 11px;
   font-weight: 300;
-  cursor: pointer;
   position: relative;
   padding: 0px 10px 0px 50px;
   box-sizing: border-box;
   overflow: hidden;
-}
-
-.c7:hover {
-  background: rgba(255, 125, 125, 0.2);
 }
 
 .c7::before {
@@ -96,10 +91,6 @@ exports[`Timeline default renders basic Timeline with a single Timeline.Item 1`]
 
 .c0 .c4:checked+.c6 {
   max-height: 300px;
-}
-
-.c0 .c4:checked+.c6:hover {
-  background: rgba(125, 255, 125, 0.2);
 }
 
 .c0 .c4:checked+.c6:before {
@@ -258,15 +249,10 @@ exports[`Timeline default renders mixture of timelines complete/not-complete 1`]
   color: #a7a7a7;
   font-size: 11px;
   font-weight: 300;
-  cursor: pointer;
   position: relative;
   padding: 0px 10px 0px 50px;
   box-sizing: border-box;
   overflow: hidden;
-}
-
-.c7:hover {
-  background: rgba(255, 125, 125, 0.2);
 }
 
 .c7::before {
@@ -312,10 +298,6 @@ exports[`Timeline default renders mixture of timelines complete/not-complete 1`]
 
 .c0 .c4:checked+.c6 {
   max-height: 300px;
-}
-
-.c0 .c4:checked+.c6:hover {
-  background: rgba(125, 255, 125, 0.2);
 }
 
 .c0 .c4:checked+.c6:before {
@@ -517,15 +499,10 @@ exports[`Timeline default renders text block if no children present in Timeline.
   color: #a7a7a7;
   font-size: 11px;
   font-weight: 300;
-  cursor: pointer;
   position: relative;
   padding: 0px 10px 0px 50px;
   box-sizing: border-box;
   overflow: hidden;
-}
-
-.c7:hover {
-  background: rgba(255, 125, 125, 0.2);
 }
 
 .c7::before {
@@ -571,10 +548,6 @@ exports[`Timeline default renders text block if no children present in Timeline.
 
 .c0 .c4:checked+.c6 {
   max-height: 300px;
-}
-
-.c0 .c4:checked+.c6:hover {
-  background: rgba(125, 255, 125, 0.2);
 }
 
 .c0 .c4:checked+.c6:before {
@@ -733,15 +706,10 @@ exports[`Timeline default renders timeline items with multiple children 1`] = `
   color: #a7a7a7;
   font-size: 11px;
   font-weight: 300;
-  cursor: pointer;
   position: relative;
   padding: 0px 10px 0px 50px;
   box-sizing: border-box;
   overflow: hidden;
-}
-
-.c7:hover {
-  background: rgba(255, 125, 125, 0.2);
 }
 
 .c7::before {
@@ -787,10 +755,6 @@ exports[`Timeline default renders timeline items with multiple children 1`] = `
 
 .c0 .c4:checked+.c6 {
   max-height: 300px;
-}
-
-.c0 .c4:checked+.c6:hover {
-  background: rgba(125, 255, 125, 0.2);
 }
 
 .c0 .c4:checked+.c6:before {

--- a/src/Timeline/common.tsx
+++ b/src/Timeline/common.tsx
@@ -42,15 +42,10 @@ const Label = styled('label')`
   color: ${(props: React.CSSProperties) => props.color || '#a7a7a7'};
   font-size: 11px;
   font-weight: 300;
-  cursor: pointer;
   position: relative;
   padding: 0px 10px 0px 50px;
   box-sizing: border-box;
   overflow: hidden;
-
-  &:hover {
-    background: rgba(255, 125, 125, 0.2);
-  }
 
   &::before {
     content: '';
@@ -94,9 +89,6 @@ const Container = styled('div')`
   }
 
   ${Input}:checked + ${Label} {
-    &:hover {
-      background: rgba(125, 255, 125, 0.2);
-    }
     max-height: 300px;
   }
 


### PR DESCRIPTION
[Minor improvements to sidepanel and other components](https://github.com/digicatapult/ui-component-library/commit/ab727d298c348881d355bacf5c9b7cea14a43df0)

1. Side panel transparency has been adjusted and borders added to list cards in the hyproof variant. This has been done to improve contrast.
2. Fixed bug that removed background from listcard when not using hyproof variant
3. Removed timeline hover
4. Removed unnecesaary comments from button


https://github.com/digicatapult/ui-component-library/assets/29942957/b93321a9-f0da-4ef3-84d0-3ccadc70730f

![Screenshot 2024-03-08 at 17 37 14](https://github.com/digicatapult/ui-component-library/assets/29942957/0e956b66-edb5-4cb4-8194-18f46fe02ddb)
![Screenshot 2024-03-08 at 17 37 36](https://github.com/digicatapult/ui-component-library/assets/29942957/c13bd71c-b1c7-4878-b864-0e73d2952dc8)

