### PR TITLE
HYP-126: removing title from a side panel.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/ui-component-library",
-      "version": "0.19.4",
+      "version": "0.19.5",
       "license": "Apache-2.0",
       "dependencies": {
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/ui-component-library",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "UI Component Library",
   "author": "Digital Catapult (https://www.digicatapult.org.uk)",
   "license": "Apache-2.0",

--- a/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/src/Navigation/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -189,7 +189,7 @@ exports[`SidePanel default 1`] = `
   <div
     className="c2"
   >
-    test heading (undefined)
+    test heading
   </div>
   <div
     className="c3"
@@ -474,7 +474,7 @@ exports[`SidePanel hyproof 1`] = `
   <div
     className="c3"
   >
-    test heading (undefined)
+    test heading
   </div>
   <div
     className="c4"

--- a/src/Navigation/SidePanel/index.tsx
+++ b/src/Navigation/SidePanel/index.tsx
@@ -13,7 +13,6 @@ import Avatar from '../../UserIcon/index.js'
 
 export interface SidePanelProps {
   heading?: string
-  title?: string
   variant: 'default' | 'hyproof'
   width?: string
   isOpen?: boolean
@@ -78,7 +77,7 @@ const SidePanel: ISidePanel & IItem = ({
   heading,
   ...props
 }) => {
-  const { variant, isOpen, width, title } = props
+  const { variant, isOpen, width } = props
   const [show, setShow] = React.useState(isOpen)
 
   const Panel = variant === 'default' ? DefaultPanel : HiiVariantPanel
@@ -101,7 +100,7 @@ const SidePanel: ISidePanel & IItem = ({
       >
         <SideArrowCloseIcon />
       </Button>
-      <Heading>{`${heading} (${title})`}</Heading>
+      <Heading>{heading}</Heading>
       {children}
     </Panel>
   )


### PR DESCRIPTION
# What

Removing title from a side panel component so it renders only a header. 


<img width="419" alt="Screenshot 2024-03-12 at 2 59 50 pm" src="https://github.com/digicatapult/ui-component-library/assets/11794402/90051f8b-8cb7-482a-a821-71b3dd4f40fd">
